### PR TITLE
fix: correct case sensitivity in CallToAction export path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -46,7 +46,7 @@ export { default as HandDrive } from './src/components/HandDrive.astro';
 export { default as Faq } from './src/components/Faq.astro';
 export { default as FaqItem } from './src/components/FaqItem.astro';
 export { default as ButtonCopy } from './src/components/ButtonCopy.astro';
-export { default as CallToAction } from './src/components/Layout/CallToAction.astro';
+export { default as CallToAction } from './src/components/layout/CallToAction.astro';
 
 export { default as ProductImage } from './src/components/Product/ProductImage.astro';
 export { default as ProductEngine } from './src/components/Product/ProductEngine.astro';


### PR DESCRIPTION
## Summary
- Fix case sensitivity issue in `CallToAction` component export path
- Change `Layout` to `layout` to match actual folder name
- Resolves build failures on case-sensitive file systems (Linux/Netlify)

## Test plan
- [x] Build passes locally
- [ ] Verify Netlify build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal file path references. No changes to user-visible functionality or features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->