### PR TITLE
feat: export useFormatProductNumber utility

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/index.ts
+++ b/index.ts
@@ -61,6 +61,7 @@ export { default as getPriceFormatted } from './src/utils/product/getPriceFormat
 export { default as getProductChecklist } from './src/utils/product/getProductChecklist';
 export { getEngineTooltipContent } from './src/utils/product/getEngineTooltipContent';
 export type { Engine, EngineTranslations } from './src/utils/product/getEngineTooltipContent';
+export { default as useFormatProductNumber } from './src/utils/product/useFormatProductNumber';
 
 // Utils: SEO
 export { default as getShorterDescription } from './src/utils/seo/getShorterDescription';

--- a/src/components/Category/CategoryTile.astro
+++ b/src/components/Category/CategoryTile.astro
@@ -18,19 +18,21 @@ const { CategoryObject } = Astro.props;
 const { height = 70, width = 70, path } = CategoryObject;
 ---
 
-<a href={path} class="carousel-item" data-astro-prefetch itemprop="url">
-  <Image
-    src={CategoryObject.photo}
-    alt={CategoryObject.alt}
-    height={height}
-    width={width}
-    format="avif"
-    loading="eager"
-    onerror="this.style.display='none';"
-    class="cats-img"
-  />
-  <div class="swiper-lazy-preloader"></div>
-  <div class="cat-name" itemprop="name">
-    {CategoryObject.name}
-  </div>
-</a>
+<span itemprop="name">
+  <a itemprop="url" href={path} class="carousel-item" data-astro-prefetch>
+    <Image
+      src={CategoryObject.photo}
+      alt={CategoryObject.alt}
+      height={height}
+      width={width}
+      format="avif"
+      loading="eager"
+      onerror="this.style.display='none';"
+      class="cats-img"
+    />
+    <div class="swiper-lazy-preloader"></div>
+    <div class="cat-name">
+      {CategoryObject.name}
+    </div>
+  </a>
+</span>


### PR DESCRIPTION
Add useFormatProductNumber to package exports for use in catalog schema identifier formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new utility export for product number formatting, enhancing the public API with additional product data formatting capabilities.

* **Chores**
  * Updated type system references to strengthen type definitions and resolution.
  * Optimized component markup structure with improved semantic attribute organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->