### PR TITLE
feat(a11y): add aria-expanded to sidebar toggle button

### DIFF
--- a/src/components/Category/CategoryDetails.astro
+++ b/src/components/Category/CategoryDetails.astro
@@ -120,6 +120,9 @@ const subcategoryPath = subcategory?.path || `/${category.slug}/${subcategory?.s
         expandedIcon.classList.toggle('hidden', isCollapsed);
         collapsedIcon.classList.toggle('hidden', !isCollapsed);
       }
+
+      // Update aria-expanded for accessibility
+      toggler.setAttribute('aria-expanded', !isCollapsed);
     });
   }
 

--- a/src/components/Category/CategorySidebarToggler.vue
+++ b/src/components/Category/CategorySidebarToggler.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="category-toggler md:w-8" type="button" aria-label="toggle menu">
+  <button class="category-toggler md:w-8" type="button" aria-label="Toggle category sidebar">
     <slot />
   </button>
 </template>


### PR DESCRIPTION
## Summary
- Adds `aria-expanded` attribute to sidebar toggle button
- Updates when sidebar collapses/expands
- Improves `aria-label` to be more descriptive

## Changes
- **CategoryDetails.astro**: Add `aria-expanded` update in `updateTogglers()` function
- **CategorySidebarToggler.vue**: Improve aria-label from "toggle menu" to "Toggle category sidebar"

## Accessibility Impact
- Screen readers now announce sidebar state (expanded/collapsed)
- Follows WCAG 2.1 Level AA guidelines for interactive controls
- Better experience for keyboard and assistive technology users

## Test Plan
- [ ] Test with screen reader (NVDA/JAWS) - announces "Toggle category sidebar, expanded" or "collapsed"
- [ ] Verify aria-expanded updates when clicking toggle button
- [ ] Test keyboard navigation (Tab to focus, Enter/Space to toggle)
- [ ] Visual regression test - no UI changes expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Enhanced category sidebar accessibility with improved screen reader support
  * Updated sidebar toggle labeling for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->