### PR TITLE
fix(CategoryDetails): prevent sidebar flash during view transitions

### DIFF
--- a/src/components/Category/CategoryDetails.astro
+++ b/src/components/Category/CategoryDetails.astro
@@ -101,18 +101,20 @@ const subcategoryPath = subcategory?.path || `/${category.slug}/${subcategory?.s
 </div>
 
 <script>
-  function initializeSidebar() {
-    const sidebar = document.getElementById('sidebar');
+  function applySidebarState(doc: Document) {
+    const sidebar = doc.getElementById('sidebar');
     const savedState = localStorage.getItem('sidebarState') || 'open';
+    const isCollapsed = savedState === 'closed';
 
     if (sidebar) {
-      sidebar.classList.toggle('collapsed', savedState === 'closed');
-      updateTogglers(savedState === 'closed');
+      sidebar.classList.toggle('collapsed', isCollapsed);
     }
+
+    updateTogglers(doc, isCollapsed);
   }
 
-  function updateTogglers(isCollapsed) {
-    document.querySelectorAll('.category-sidebar-toggler').forEach(toggler => {
+  function updateTogglers(doc: Document, isCollapsed: boolean) {
+    doc.querySelectorAll('.category-sidebar-toggler').forEach(toggler => {
       const expandedIcon = toggler.querySelector('.expanded-icon');
       const collapsedIcon = toggler.querySelector('.collapsed-icon');
 
@@ -121,8 +123,7 @@ const subcategoryPath = subcategory?.path || `/${category.slug}/${subcategory?.s
         collapsedIcon.classList.toggle('hidden', !isCollapsed);
       }
 
-      // Update aria-expanded for accessibility
-      toggler.setAttribute('aria-expanded', !isCollapsed);
+      toggler.setAttribute('aria-expanded', String(!isCollapsed));
     });
   }
 
@@ -138,7 +139,7 @@ const subcategoryPath = subcategory?.path || `/${category.slug}/${subcategory?.s
         const isCollapsed = sidebar.classList.toggle('collapsed');
         document.body.classList.remove('overflow-hidden');
         localStorage.setItem('sidebarState', isCollapsed ? 'closed' : 'open');
-        updateTogglers(isCollapsed);
+        updateTogglers(document, isCollapsed);
       }
     }
   }
@@ -150,27 +151,15 @@ const subcategoryPath = subcategory?.path || `/${category.slug}/${subcategory?.s
     });
   }
 
-  // Initialize on page load
+  // Initialize on page load (initial + after view transitions)
   document.addEventListener('astro:page-load', () => {
-    initializeSidebar();
+    applySidebarState(document);
     setupTogglers();
   });
 
-  // Preserve state during view transitions
-  document.addEventListener('astro:before-swap', () => {
-    const sidebarState = localStorage.getItem('sidebarState');
-    if (sidebarState) {
-      sessionStorage.setItem('tempSidebarState', sidebarState);
-    }
-  });
-
-  document.addEventListener('astro:after-swap', () => {
-    const tempState = sessionStorage.getItem('tempSidebarState');
-    if (tempState) {
-      localStorage.setItem('sidebarState', tempState);
-      sessionStorage.removeItem('tempSidebarState');
-      initializeSidebar();
-    }
+  // Apply sidebar state to incoming DOM BEFORE swap to prevent flash
+  document.addEventListener('astro:before-swap', e => {
+    applySidebarState(e.newDocument);
   });
 </script>
 


### PR DESCRIPTION
## Summary
- Use `e.newDocument` in `astro:before-swap` to apply sidebar collapsed state before DOM swap, eliminating the layout flash during View Transitions
- Remove redundant `sessionStorage` round-trip (`localStorage` persists across navigations)
- Pass `Document` parameter to `updateTogglers` for reuse across contexts
- Fix `aria-expanded` to pass string value

## Test plan
- [ ] Navigate between categories with sidebar collapsed — no layout flash
- [ ] Navigate between categories with sidebar expanded — no flash
- [ ] Toggle sidebar collapse/expand — state persists after navigation
- [ ] Refresh page — sidebar state restored from localStorage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated visual flashing during page navigation, improving the smoothness of transitions between pages.
  * Optimized sidebar state handling to prevent visual artifacts when navigating.

* **Changes**
  * Sidebar collapse state now resets upon page navigation instead of persisting across page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->