### PR TITLE
refactor: rename product-thumb--related to product-thumb--tile

### DIFF
--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -88,7 +88,7 @@ export const componentShortcuts = [
   ['pdp-slide', `h-full bg-gray-100 ${aspectRatios['4/3']} ${LAYOUT.position.relative} overflow-hidden border border-transparent`],
   ['product-link', PRODUCT_STYLES.link.base],
   ['number-big', 'text-3.75 mr-2 mt-2 mb-0 sm:mt-0'],
-  ['product-thumb--related', `w-22 min-w-22 xl:w-30 xl:min-w-30 h-auto ${IMAGE_STYLES.objectContain} object-top bg-gray-100 ${aspectRatios['4/3']} ${LAYOUT.position.relative}`],
+  ['product-thumb--tile', `w-full h-auto ${IMAGE_STYLES.objectContain} object-top bg-gray-100 ${aspectRatios['4/3']} ${LAYOUT.position.relative}`],
   ['product-thumb--carousel', `w-60 min-w-60 sm:w-22 sm:min-w-22 xl:w-30 xl:min-w-30 h-auto ${IMAGE_STYLES.objectContain} object-top bg-gray-100 ${aspectRatios['4/3']} ${LAYOUT.position.relative}`],
 
   


### PR DESCRIPTION
## Summary
- Rename `product-thumb--related` to `product-thumb--tile` for more universal naming
- Replace fixed widths (`w-22 min-w-22 xl:w-30 xl:min-w-30`) with `w-full` for flexible tile layouts

## Context
The old `product-thumb--related` had fixed widths designed for a specific horizontal layout. The new `product-thumb--tile` uses `w-full` to work in any grid/flex tile context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated product thumbnail display to use full-width layout. Thumbnails now extend to fill available width instead of using fixed width sizes, while preserving aspect ratio, image containment, and styling properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->