### PR TITLE
fix: restore product-thumb--related, add product-thumb--tile

### DIFF
--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -205,6 +205,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("../src/content.config.mjs");
+	export type ContentConfig = typeof import("./../src/content.config.mjs");
 	export type LiveContentConfig = never;
 }

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -88,6 +88,7 @@ export const componentShortcuts = [
   ['pdp-slide', `h-full bg-gray-100 ${aspectRatios['4/3']} ${LAYOUT.position.relative} overflow-hidden border border-transparent`],
   ['product-link', PRODUCT_STYLES.link.base],
   ['number-big', 'text-3.75 mr-2 mt-2 mb-0 sm:mt-0'],
+  ['product-thumb--related', `w-22 min-w-22 xl:w-30 xl:min-w-30 h-auto ${IMAGE_STYLES.objectContain} object-top bg-gray-100 ${aspectRatios['4/3']} ${LAYOUT.position.relative}`],
   ['product-thumb--tile', `w-full h-auto ${IMAGE_STYLES.objectContain} object-top bg-gray-100 ${aspectRatios['4/3']} ${LAYOUT.position.relative}`],
   ['product-thumb--carousel', `w-60 min-w-60 sm:w-22 sm:min-w-22 xl:w-30 xl:min-w-30 h-auto ${IMAGE_STYLES.objectContain} object-top bg-gray-100 ${aspectRatios['4/3']} ${LAYOUT.position.relative}`],
 


### PR DESCRIPTION
## Summary
- Restore `product-thumb--related` with original fixed widths (`w-22`/`w-30`) — was accidentally removed in #345
- Add `product-thumb--tile` as a new class with `w-full` for flexible tile/grid layouts

## Context
PR #345 renamed `product-thumb--related` to `product-thumb--tile`, removing the fixed-width variant. This broke layouts that depend on the fixed thumbnail size next to text. This PR restores the original and keeps the new class as an addition.