### PR TITLE
feat: add 2-column grid layout for view-list on 4xl screens

### DIFF
--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -205,6 +205,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("../src/content.config.mjs");
+	export type ContentConfig = typeof import("./../src/content.config.mjs");
 	export type LiveContentConfig = never;
 }

--- a/uno-config/theme/shortcuts/layout.ts
+++ b/uno-config/theme/shortcuts/layout.ts
@@ -29,7 +29,7 @@ export const layoutShortcuts = [
 
   // View Toggles
   ['view-grid', 'lg:flex-wrap'],
-  ['view-list', 'lg:flex-col divide-y-1 divide-solid divide-neutral-lighter 4xl:(grid grid-cols-2 gap-14)'],
+  ['view-list', 'md:block lg:flex-col divide-y-1 divide-solid divide-neutral-lighter 4xl:(grid grid-cols-2 gap-14)'],
 
   // Containers
   ['products-container', 'products-wrapper'],

--- a/uno-config/theme/shortcuts/layout.ts
+++ b/uno-config/theme/shortcuts/layout.ts
@@ -29,7 +29,7 @@ export const layoutShortcuts = [
 
   // View Toggles
   ['view-grid', 'lg:flex-wrap'],
-  ['view-list', 'lg:flex-col divide-y-1 divide-solid divide-neutral-lighter'],
+  ['view-list', 'lg:flex-col divide-y-1 divide-solid divide-neutral-lighter 4xl:(grid grid-cols-2 gap-14)'],
 
   // Containers
   ['products-container', 'products-wrapper'],


### PR DESCRIPTION
## Summary
- Add `4xl:(grid grid-cols-2 gap-14)` to `view-list` shortcut for 2-column layout on wide screens (2400px+)

## Test plan
- [x] Tested locally with linked SDS in catalog.polo.blue
- [ ] Verify view-list displays as 2-column grid on viewports >= 2400px
- [ ] Verify no layout changes on smaller breakpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layout behavior for list view toggle across different screen sizes, with optimized spacing and grid layout on extra-large displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->