### PR TITLE
refactor: remove ButtonCopy from ProductNumber

### DIFF
--- a/src/components/Product/ProductNumber.astro
+++ b/src/components/Product/ProductNumber.astro
@@ -1,15 +1,7 @@
 ---
-import ButtonCopy from '../ButtonCopy.astro';
 import useFormatProductNumber from '../../utils/product/useFormatProductNumber';
 
-const {
-  productNumber,
-  isPdp = false,
-  small = false,
-  big = false,
-  class: customClass = '',
-  buttonTexts = { copy: 'Copy', copied: 'Copied' },
-} = Astro.props;
+const { productNumber, isPdp = false, small = false, big = false, class: customClass = '' } = Astro.props;
 
 // Use formatted product number using a helper function
 const { formattedNumbers: formatted } = useFormatProductNumber(productNumber);
@@ -32,7 +24,7 @@ const FormattedWrapper = isPdp ? 'h3' : 'div';
           {productNumber}
         </ProductWrapper>
 
-        {big && <ButtonCopy productNumber={productNumber} texts={buttonTexts} tooltipClasses="" />}
+        <slot name="after-number" />
       </div>
 
       <div class={['code-formatted', trackingClass].join(' ')}>

--- a/src/pages/components/product-number.mdx
+++ b/src/pages/components/product-number.mdx
@@ -8,10 +8,13 @@ productNumbers:
   - "N0385491"
 ---
 import ProductNumber from '../../components/Product/ProductNumber.astro'
+import ButtonCopy from '../../components/ButtonCopy.astro'
 
 # ProductNumber
 
-ProductNumber - with additional formatting adding spacing for Volkswagen product numbers + additional copy button for easier copying.
+ProductNumber - with additional formatting adding spacing for Volkswagen product numbers.
+
+Use the `after-number` slot to add a copy button or other actions next to the product number (e.g. on PDP pages).
 
 #
 <div class="component-preview">
@@ -35,14 +38,19 @@ ProductNumber - with additional formatting adding spacing for Volkswagen product
 />
 ```
 
+### With ButtonCopy (PDP usage)
+
 <div class="component-preview">
   <div class="grid grid-cols-2 lg:grid-cols-4 gap-x-4 w-full bg-white p-y-5 px-4">
    {frontmatter.productNumbers.map((number, index) => (
       <ProductNumber
         big
+        isPdp
         productNumber={number}
         class="mb-2"
-      />
+      >
+        <ButtonCopy slot="after-number" productNumber={number} texts={{ copy: 'Copy', copied: 'Copied' }} />
+      </ProductNumber>
     ))}
   </div>
 </div>


### PR DESCRIPTION
## Summary

- Remove `ButtonCopy` import from `ProductNumber` component
- Add `after-number` named slot for consumers to place ButtonCopy when needed
- Prevents ButtonCopy JS from loading on pages that don't need copy functionality (category pages, homepage)

## Breaking Change

`ButtonCopy` is no longer rendered automatically when `big` prop is set. Consumers must use the `after-number` slot:

```astro
<ProductNumber big isPdp productNumber="6R0601025D8Z8">
  <ButtonCopy slot="after-number" productNumber="6R0601025D8Z8" texts={{ copy: 'Copy', copied: 'Copied' }} />
</ProductNumber>
```

## Test plan

- [ ] SDS docs: product-number page renders correctly
- [ ] catalog.polo.blue: PDP still shows copy button (after updating ProductInfoSection)
- [ ] catalog.polo.blue: category pages no longer load ButtonCopy JS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * ProductNumber component now supports custom content injection through slots instead of built-in button rendering.

* **Documentation**
  * Added examples demonstrating how to customize content displayed alongside the product number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->