### PR TITLE
fix(ButtonCopy): prevent double-click race condition and View Transitions duplicate listeners

### DIFF
--- a/src/components/ButtonCopy.astro
+++ b/src/components/ButtonCopy.astro
@@ -33,12 +33,11 @@ const COPY_ICON = `url("data:image/svg+xml;utf8,${encodeURIComponent(
   class ClipboardButton {
     private static readonly COPY_TIMEOUT = 2000;
     private static readonly ANALYTICS_EVENT = 'product_code_copy';
+    private readonly originalText: string;
+    private resetTimer: ReturnType<typeof setTimeout> | null = null;
 
     constructor(private button: HTMLButtonElement) {
-      this.init();
-    }
-
-    private init(): void {
+      this.originalText = this.tooltip?.dataset.text || 'Copy';
       this.button.addEventListener('click', () => this.handleCopy());
     }
 
@@ -52,10 +51,6 @@ const COPY_ICON = `url("data:image/svg+xml;utf8,${encodeURIComponent(
 
     private get category(): string {
       return this.button.dataset.category || '';
-    }
-
-    private get originalText(): string {
-      return this.tooltip.dataset.text || 'Copy';
     }
 
     private get copiedText(): string {
@@ -93,9 +88,11 @@ const COPY_ICON = `url("data:image/svg+xml;utf8,${encodeURIComponent(
     }
 
     private updateTooltip(): void {
+      if (this.resetTimer) clearTimeout(this.resetTimer);
       this.tooltip.dataset.text = this.copiedText;
-      setTimeout(() => {
+      this.resetTimer = setTimeout(() => {
         this.tooltip.dataset.text = this.originalText;
+        this.resetTimer = null;
       }, ClipboardButton.COPY_TIMEOUT);
     }
 
@@ -118,10 +115,11 @@ const COPY_ICON = `url("data:image/svg+xml;utf8,${encodeURIComponent(
     }
   }
 
-  // Initialize copy buttons on page load
+  // Initialize copy buttons on page load (skip already-initialized for View Transitions)
   document.addEventListener('astro:page-load', () => {
     document.querySelectorAll('.btn-copy').forEach(button => {
-      if (button instanceof HTMLButtonElement) {
+      if (button instanceof HTMLButtonElement && !button.dataset.copyInit) {
+        button.dataset.copyInit = '1';
         new ClipboardButton(button);
       }
     });


### PR DESCRIPTION
## Summary

- Cache `originalText` at construction time instead of reading from mutated `dataset.text` on each click — fixes tooltip getting stuck on "Copied" after rapid double-click
- `clearTimeout` previous reset timer on rapid clicks so only the last click's timer runs
- Add `data-copy-init` guard to prevent duplicate event listeners when `astro:page-load` fires multiple times with View Transitions

## Test plan

- [ ] Click copy button once — tooltip shows "Copied", reverts to original after 2s
- [ ] Double-click copy button rapidly — tooltip shows "Copied", reverts correctly after 2s (no stuck state)
- [ ] Navigate away and back (View Transitions) — copy button still works, no duplicate click handlers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Copy button tooltip now properly resets after displaying the "Copied" confirmation message.
  * Fixed copy button initialization issue that could occur when navigating between pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->