### PR TITLE
feat(ProductDetailsList): support individual link items

### DIFF
--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -205,6 +205,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("../src/content.config.mjs");
+	export type ContentConfig = typeof import("./../src/content.config.mjs");
 	export type LiveContentConfig = never;
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,13 +13,13 @@
       "Bash(git diff:*)",
       "Bash(git log:*)",
       "Bash(git add:*)",
-      "Bash(git commit:*)"
+      "Bash(git commit:*)",
       "Bash(git push:*)"
     ],
     "deny": [
       "Bash(pnpm semantic-release:*)",
       "Bash(pnpm publish:*)",
-      "Bash(npm publish:*)",
+      "Bash(npm publish:*)"
     ],
     "ask": [
       "Bash(rm:*)",

--- a/src/components/ProductDetailsList.vue
+++ b/src/components/ProductDetailsList.vue
@@ -10,7 +10,8 @@ interface Link {
 
 interface TableItem {
   id: string;
-  label: string; // Display name from API
+  label?: string; // Display name from API
+  name?: string; // Alternative display name (used by individual link items)
   value: unknown; // Can be string, number, boolean, string array, or Link array
   type?: string; // 'links' for link arrays
   isGenericArray?: boolean; // for generic string arrays (e.g., position)
@@ -21,9 +22,15 @@ const props = defineProps({
   caption: { type: String, default: null },
 });
 
-// Function to check if it's a links array from new API
+// Function to check if it's a links array (legacy grouped format)
 const isLinksArray = (item: TableItem) => {
   return item.type === 'links' && Array.isArray(item.value);
+};
+
+// Function to check if it's an individual link item
+// Backend sends: { id: 'blog', name: 'anchor', value: 'https://...', type: 'link' }
+const isIndividualLink = (item: TableItem) => {
+  return item.type === 'link' && typeof item.value === 'string';
 };
 
 // Function to check if it's a generic array (e.g., for position)
@@ -106,6 +113,21 @@ const validatedItems = computed(() => {
               </a>
             </li>
           </ul>
+        </td>
+
+        <!-- Individual Link (flat format: id=blog/youtube/vimeo, value=url, name=anchor) -->
+        <td v-else-if="isIndividualLink(row)" class="details-table-cell">
+          <div class="flex items-center">
+            <span
+              :class="[
+                getLinkIconClass(row.id),
+                'leading-none inline-block mr-2 w-4 min-w-4 h-4 text-gray-400',
+              ]"
+            />
+            <a :href="row.value as string" target="_blank" rel="noopener noreferrer" class="link-primary">
+              {{ row.name || row.label || row.id }}
+            </a>
+          </div>
         </td>
 
         <!-- Generic String Array -->


### PR DESCRIPTION
## Summary
- Add support for individual link items with `type='link'` in `ProductDetailsList`
- Backend now sends each product link as a separate comprehensive item: `{id: 'blog', name: 'anchor', value: 'url', type: 'link'}`
- Component detects links via `type='link'` marker, making it independent of specific link type IDs
- Legacy grouped `type='links'` format still supported for backward compatibility

## Related
- polo-blue/panel.polo.blue#118 — backend changes

## Test plan
- [ ] Verify individual link items render with correct icon and anchor text
- [ ] Verify legacy grouped links format still works
- [ ] Verify non-link items are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product details list component now supports a new flat format for displaying individual links, providing greater flexibility in layout and presentation options alongside existing grouped link structures.

* **Chores**
  * Updated configuration settings and import paths for improved consistency across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->