### PR TITLE
fix: prevent script hoisting from barrel file for Astro components

### DIFF
--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -205,6 +205,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("../src/content.config.mjs");
+	export type ContentConfig = typeof import("./../src/content.config.mjs");
 	export type LiveContentConfig = never;
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,26 @@ export { default as Button } from './src/components/Button.vue';
 export { default as Button } from './components/Button.vue';
 ```
 
+### Astro Components with `<script>` Tags — Barrel File Restriction
+
+Astro components with `<script>` tags **MUST NOT** be exported from the barrel file (`index.ts`).
+When any consumer imports from the barrel, Astro hoists ALL `<script>` tags from ALL exported `.astro`
+components onto every page — even if the component is never rendered. This is a
+[known Astro limitation](https://github.com/withastro/astro/issues/6906).
+
+**Rule:** If an `.astro` component has a `<script>` tag, export it ONLY via subpath (`./components/*`):
+```typescript
+// ❌ DO NOT add to index.ts — script will load on ALL consumer pages
+export { default as ButtonCopy } from './src/components/ButtonCopy.astro';
+
+// ✅ Consumer uses direct subpath import instead
+import ButtonCopy from 'spoko-design-system/components/ButtonCopy.astro';
+```
+
+Components **without** `<script>` tags are safe in the barrel file.
+
+Currently excluded from barrel: **ButtonCopy**, **CategoryDetails**, **LanguageSuggestion**.
+
 ### UnoCSS Configuration System
 
 **Critical**: UnoCSS config is split across two locations:
@@ -198,10 +218,12 @@ On merge to `main`, GitHub Actions automatically:
    - Vue: `src/components/ComponentName.vue`
    - Astro: `src/components/ComponentName.astro`
 
-2. Export from root `index.ts`:
+2. Export from root `index.ts` (Vue components and Astro components **without** `<script>` tags):
    ```typescript
    export { default as ComponentName } from './src/components/ComponentName.vue';
    ```
+   **Important:** If the Astro component has a `<script>` tag, do **NOT** add it to `index.ts`.
+   It will be available via the wildcard subpath export `./components/*` automatically.
 
 3. Add documentation page in `src/pages/components/component-name.mdx`
 

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,6 @@ export { default as FlagPL } from './src/components/flags/FlagPL.vue';
 export { default as Badges } from './src/components/Badges.vue';
 export { default as SlimBanner } from './src/components/SlimBanner.vue';
 
-export { default as Jumbotron } from './src/components/Jumbotron.astro';
 export { default as Button } from './src/components/Button.vue';
 export { default as Breadcrumbs } from './src/components/Breadcrumbs.vue';
 export { default as ProductDetailsList } from './src/components/ProductDetailsList.vue';
@@ -29,10 +28,7 @@ export { default as ProductModel } from './src/components/Product/ProductModel.v
 export { default as ProductModels } from './src/components/Product/ProductModels.vue';
 export { default as ProductName } from './src/components/Product/ProductName.vue';
 export { default as ProductPositions } from './src/components/Product/ProductPositions.vue';
-export { default as ProductNumber } from './src/components/Product/ProductNumber.astro';
 export { default as ProductLink } from './src/components/Product/ProductLink.vue';
-// export { default as ProductCarousel } from './src/components/Product/ProductCarousel.astro';
-export { default as LanguageSuggestion } from './src/components/LanguageSuggestion.astro';
 export { default as Input } from './src/components/Input.vue';
 
 export { default as PostCategories } from './src/components/Post/PostCategories.vue';
@@ -40,20 +36,23 @@ export { default as CategorySidebarToggler } from './src/components/Category/Cat
 export { default as SubCategoryLink } from './src/components/Category/SubCategoryLink.vue';
 export { default as CategoryLink } from './src/components/Category/CategoryLink.vue';
 
-// Astro Components
-export { default as Copyright } from './src/components/Copyright.astro'; 
+// Astro Components (without <script> tags — safe in barrel)
+export { default as Jumbotron } from './src/components/Jumbotron.astro';
+export { default as Copyright } from './src/components/Copyright.astro';
 export { default as HandDrive } from './src/components/HandDrive.astro';
 export { default as Faq } from './src/components/Faq.astro';
 export { default as FaqItem } from './src/components/FaqItem.astro';
-export { default as ButtonCopy } from './src/components/ButtonCopy.astro';
 export { default as CallToAction } from './src/components/layout/CallToAction.astro';
-
+export { default as ProductNumber } from './src/components/Product/ProductNumber.astro';
 export { default as ProductImage } from './src/components/Product/ProductImage.astro';
 export { default as ProductEngine } from './src/components/Product/ProductEngine.astro';
 export { default as ProductEngines } from './src/components/Product/ProductEngines.astro';
-
-export { default as CategoryDetails } from './src/components/Category/CategoryDetails.astro';
 export { default as CategoryTile } from './src/components/Category/CategoryTile.astro';
+
+// Astro Components WITH <script> tags — NOT in barrel to prevent script hoisting.
+// Import directly: import ButtonCopy from 'spoko-design-system/components/ButtonCopy.astro'
+// See: https://github.com/withastro/astro/issues/6906
+// - ButtonCopy, CategoryDetails, LanguageSuggestion
 
 
 // Utils: Product

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "./scripts/*": "./src/scripts/*",
     "./icons": "./icon.config.ts",
     "./icon-collections": "./icon.collections.ts",
-    "./uno-config": "./uno-config/index.ts"
+    "./uno-config": "./uno-config/index.ts",
+    "./components/*": "./src/components/*"
   },
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
## Summary
- Remove 3 Astro components with `<script>` tags from barrel `index.ts`: **ButtonCopy**, **CategoryDetails**, **LanguageSuggestion**
- Keep all Astro components without `<script>` tags in barrel (safe, no side effects)
- Add wildcard subpath export `"./components/*"` in `package.json` for direct imports

## Problem
Astro components with `<script>` tags exported via barrel file cause their scripts to be hoisted and loaded on **ALL pages**, even when only imported on specific pages. This is a [known Astro architectural limitation](https://github.com/withastro/astro/issues/6906).

In catalog.polo.blue, this caused `ButtonCopy.astro_astro_type_script_index_0_lang.BGrgkx8C.js` (13.9 KB, containing tippy.js/popper.js + clipboard code) to load on homepage and category pages where it was never used.

## Migration
Components removed from barrel can be imported directly:
```ts
// Before (loads script on ALL pages)
import { ButtonCopy } from 'spoko-design-system';

// After (loads script only where imported)
import ButtonCopy from 'spoko-design-system/components/ButtonCopy.astro';
```

## Test plan
- [ ] Verify barrel imports of safe components still work (`{ Faq, HandDrive, ProductNumber, ... }`)
- [ ] Verify direct import of ButtonCopy works via subpath
- [ ] Build catalog.polo.blue — confirm ButtonCopy chunk no longer appears on non-product pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized how components are exported and grouped to clarify public surface and comments.
  * Adjusted package export mappings so component imports resolve from the components path.
  * Updated a content type reference to improve type resolution in tooling.

(Existing note replaced with the above updated summary.)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->