### PR TITLE
feat: ProductGallery — scroll-snap slider + dialog zoom

### DIFF
--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -205,6 +205,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("../src/content.config.mjs");
+	export type ContentConfig = typeof import("./../src/content.config.mjs");
 	export type LiveContentConfig = never;
 }

--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,6 @@ export default [
       },
       globals: {
         ...globals.browser,
-        NodeListOf: 'readonly',
       },
     },
     plugins: {
@@ -27,6 +26,7 @@ export default [
     },
     rules: {
       ...typescript.configs.recommended.rules,
+      'no-undef': 'off', // TypeScript handles undefined-variable checks natively
       '@typescript-eslint/no-unused-vars': 'warn',
       '@typescript-eslint/no-explicit-any': 'warn',
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import typescript from '@typescript-eslint/eslint-plugin';
 import typescriptParser from '@typescript-eslint/parser';
 import vue from 'eslint-plugin-vue';
 import astro from 'eslint-plugin-astro';
+import globals from 'globals';
 
 export default [
   js.configs.recommended,
@@ -17,9 +18,8 @@ export default [
         sourceType: 'module',
       },
       globals: {
-        console: 'readonly',
-        window: 'readonly',
-        document: 'readonly',
+        ...globals.browser,
+        NodeListOf: 'readonly',
       },
     },
     plugins: {
@@ -43,15 +43,14 @@ export default [
         sourceType: 'module',
       },
       globals: {
-        console: 'readonly',
-        window: 'readonly',
-        document: 'readonly',
+        ...globals.browser,
       },
     },
     rules: {
       'vue/multi-word-component-names': 'off',
       'vue/no-unused-vars': 'warn',
       'vue/no-required-prop-with-default': 'off', // Props with defaults can still be required in Vue 3
+      'no-redeclare': 'off', // TypeScript handles redeclare checks; avoids false positives on imported DOM types
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "eslint": "^10.0.1",
     "eslint-plugin-astro": "^1.6.0",
     "eslint-plugin-vue": "^10.8.0",
+    "globals": "^17.4.0",
     "husky": "^9.1.7",
     "jscpd": "^4.0.8",
     "prettier": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       eslint-plugin-vue:
         specifier: ^10.8.0
         version: 10.8.0(@typescript-eslint/parser@8.56.0(eslint@10.0.2(jiti@2.6.1))(typescript@5.9.2))(eslint@10.0.2(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@10.0.2(jiti@2.6.1)))
+      globals:
+        specifier: ^17.4.0
+        version: 17.4.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -3646,6 +3649,10 @@ packages:
 
   globals@16.5.0:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
+    engines: {node: '>=18'}
+
+  globals@17.4.0:
+    resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -10558,6 +10565,8 @@ snapshots:
   globals@15.15.0: {}
 
   globals@16.5.0: {}
+
+  globals@17.4.0: {}
 
   globalthis@1.0.4:
     dependencies:

--- a/src/components/Product/ProductGallery.astro
+++ b/src/components/Product/ProductGallery.astro
@@ -58,9 +58,10 @@ const total = images.length;
             {images.map((image, index) => (
               <div
                 class="pg-slide w-full min-w-full overflow-hidden md:cursor-zoom-in"
-                role="group"
+                role="button"
                 aria-roledescription="slide"
                 aria-label={`${index + 1} / ${total}`}
+                aria-haspopup="dialog"
                 data-index={index}
                 data-full={image.full || image.src}
                 tabindex="0"

--- a/src/components/Product/ProductGallery.astro
+++ b/src/components/Product/ProductGallery.astro
@@ -131,7 +131,7 @@ const total = images.length;
 
         {total > 1 && (
           <div
-            class="hidden md:flex gap-2 mt-3 pb-1 overflow-x-auto scrollbar-none"
+            class="hidden md:flex gap-2 mt-3 pb-[3px] overflow-x-auto scrollbar-none"
             data-gallery-thumbs
             role="tablist"
             aria-label="Image thumbnails"

--- a/src/components/Product/ProductGallery.astro
+++ b/src/components/Product/ProductGallery.astro
@@ -1,0 +1,323 @@
+---
+/**
+ * ProductGallery — scroll-snap based product image gallery
+ *
+ * Features:
+ * - Main slider with CSS scroll-snap (zero-JS layout)
+ * - Thumbnail strip synced via IntersectionObserver (desktop only)
+ * - Fullscreen dialog with zoom on click
+ * - Fraction counter (1/5)
+ * - Arrow navigation with hover reveal (desktop only)
+ *
+ * Subpath import (has <script> — must NOT go in barrel):
+ *   import ProductGallery from 'spoko-design-system/components/Product/ProductGallery.astro'
+ */
+
+interface GalleryImage {
+  src: string;
+  thumb?: string;
+  full?: string;
+  alt: string;
+}
+
+interface Props {
+  images: GalleryImage[];
+  aspectRatio?: string;
+  class?: string;
+  ariaLabel?: string;
+}
+
+const {
+  images = [],
+  aspectRatio = '4/3',
+  class: className,
+  ariaLabel = 'Product image gallery',
+} = Astro.props;
+const hasImages = images.length > 0;
+const total = images.length;
+---
+
+<div
+  class:list={['relative overflow-hidden drop-shadow-sm', className]}
+  data-product-gallery
+  role="region"
+  aria-roledescription="carousel"
+  aria-label={ariaLabel}
+>
+  {
+    hasImages ? (
+      <>
+        <div class="pg-main relative overflow-hidden bg-neutral-lightest">
+          <div
+            class="pg-slider flex overflow-x-auto overflow-y-hidden"
+            style={`aspect-ratio: ${aspectRatio}`}
+            data-gallery-slider
+            tabindex="0"
+            role="group"
+          >
+            {images.map((image, index) => (
+              <div
+                class="pg-slide w-full min-w-full overflow-hidden md:cursor-zoom-in"
+                role="group"
+                aria-roledescription="slide"
+                aria-label={`${index + 1} / ${total}`}
+                data-index={index}
+                data-full={image.full || image.src}
+              >
+                <img
+                  src={image.src}
+                  alt={image.alt}
+                  loading={index === 0 ? 'eager' : 'lazy'}
+                  decoding={index === 0 ? 'sync' : 'async'}
+                  class="w-full h-full object-cover"
+                  width="800"
+                  height="600"
+                />
+              </div>
+            ))}
+          </div>
+
+          <div
+            class="absolute bottom-0 left-0 z-10 px-3 py-0.5 text-sm leading-relaxed bg-neutral-lighter/70 sm:(px-4 py-1 text-base)"
+            data-gallery-counter
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            <span data-gallery-current>1</span>/{total}
+          </div>
+
+          <button
+            type="button"
+            class="pg-arrow hidden md:flex absolute top-50% left-0 z-10 w-10 h-10 items-center justify-center border-none bg-transparent text-primary-400 cursor-pointer drop-shadow-md"
+            data-gallery-prev
+            data-dir="prev"
+            aria-label="Previous image"
+            disabled
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="22"
+              height="22"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              aria-hidden="true"
+            >
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="pg-arrow hidden md:flex absolute top-50% right-0 z-10 w-10 h-10 items-center justify-center border-none bg-transparent text-primary-400 cursor-pointer drop-shadow-md"
+            data-gallery-next
+            data-dir="next"
+            aria-label="Next image"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="22"
+              height="22"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              aria-hidden="true"
+            >
+              <polyline points="9 6 15 12 9 18" />
+            </svg>
+          </button>
+
+          <slot />
+        </div>
+
+        {total > 1 && (
+          <div
+            class="hidden md:flex gap-2 mt-3 pb-1 overflow-x-auto scrollbar-none"
+            data-gallery-thumbs
+            role="tablist"
+            aria-label="Image thumbnails"
+          >
+            {images.map((image, index) => (
+              <button
+                type="button"
+                class:list={[
+                  'pg-thumb shrink-0 h-20 w-auto p-0 border-2 border-transparent rounded-sm cursor-pointer bg-transparent overflow-hidden',
+                  { 'is-active': index === 0 },
+                ]}
+                data-thumb-index={index}
+                role="tab"
+                aria-selected={index === 0 ? 'true' : 'false'}
+                aria-label={`Image ${index + 1}`}
+              >
+                <img
+                  src={image.thumb || image.src}
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                  class="h-full w-auto object-cover block"
+                  width="160"
+                  height="120"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+
+        <dialog
+          class="pg-dialog fixed inset-0 w-full h-full max-w-full max-h-full p-0 m-0 border-none bg-black/95 text-white z-1050"
+          data-gallery-dialog
+          aria-label="Full-screen image gallery"
+        >
+          <div class="flex items-center justify-between px-4 py-3 shrink-0">
+            <span class="text-sm text-neutral-200" data-dialog-counter aria-live="polite" aria-atomic="true">
+              <span data-dialog-current>1</span>/{total}
+            </span>
+            <button
+              type="button"
+              class="flex items-center justify-center w-10 h-10 border-none bg-transparent text-neutral-400 cursor-pointer hover:text-white transition-colors"
+              data-dialog-close
+              aria-label="Close gallery"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                width="24"
+                height="24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                aria-hidden="true"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+
+          <div
+            class="pg-dialog-slider flex flex-1 min-h-0 overflow-x-auto overflow-y-hidden"
+            data-dialog-slider
+            tabindex="0"
+            role="group"
+          >
+            {images.map((image, index) => (
+              <div
+                class="pg-slide w-full min-w-full flex items-center justify-center"
+                role="group"
+                aria-roledescription="slide"
+                aria-label={`${index + 1} / ${total}`}
+                data-index={index}
+              >
+                <div class="pg-zoom" data-zoom-container>
+                  <img
+                    src={image.full || image.src}
+                    alt={image.alt}
+                    loading={index === 0 ? 'eager' : 'lazy'}
+                    decoding={index === 0 ? 'sync' : 'async'}
+                    class="pg-zoom-img"
+                    width="1600"
+                    height="1200"
+                    data-zoom-img
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <button
+            type="button"
+            class="pg-dialog-arrow hidden md:flex absolute top-50% left-3 -translate-y-50% z-10 w-12 h-12 items-center justify-center border-none bg-black/45 text-neutral-400 cursor-pointer rounded transition-colors"
+            data-dialog-prev
+            aria-label="Previous image"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="28"
+              height="28"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              aria-hidden="true"
+            >
+              <polyline points="15 18 9 12 15 6" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="pg-dialog-arrow hidden md:flex absolute top-50% right-3 -translate-y-50% z-10 w-12 h-12 items-center justify-center border-none bg-black/45 text-neutral-400 cursor-pointer rounded transition-colors"
+            data-dialog-next
+            aria-label="Next image"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="28"
+              height="28"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              aria-hidden="true"
+            >
+              <polyline points="9 6 15 12 9 18" />
+            </svg>
+          </button>
+
+          {total > 1 && (
+            <div
+              class="flex shrink-0 gap-1 px-4 py-2 pb-3 justify-center overflow-x-auto scrollbar-none bg-black/80"
+              data-dialog-thumbs
+              role="tablist"
+              aria-label="Image thumbnails"
+            >
+              {images.map((image, index) => (
+                <button
+                  type="button"
+                  class:list={[
+                    'pg-dialog-thumb shrink-0 h-15 w-auto p-0 border-2 border-transparent rounded-sm cursor-pointer bg-transparent overflow-hidden',
+                    { 'is-active': index === 0 },
+                  ]}
+                  data-thumb-index={index}
+                  role="tab"
+                  aria-selected={index === 0 ? 'true' : 'false'}
+                  aria-label={`Image ${index + 1}`}
+                >
+                  <img
+                    src={image.thumb || image.src}
+                    alt=""
+                    loading="lazy"
+                    decoding="async"
+                    class="h-full w-auto object-cover block"
+                    width="100"
+                    height="75"
+                  />
+                </button>
+              ))}
+            </div>
+          )}
+        </dialog>
+      </>
+    ) : (
+      <div
+        class="flex items-center justify-center bg-neutral-lightest text-neutral-500"
+        style={`aspect-ratio: ${aspectRatio}`}
+      >
+        <slot name="empty">
+          <p>No images available</p>
+        </slot>
+      </div>
+    )
+  }
+</div>
+
+<style>
+  @import './product-gallery.css';
+</style>
+
+<script>
+  import { initProductGallery } from './product-gallery.ts';
+
+  document.addEventListener('astro:page-load', () => {
+    document.querySelectorAll<HTMLElement>('[data-product-gallery]').forEach(el => {
+      if (el.dataset.galleryInit) return;
+      el.dataset.galleryInit = '1';
+      initProductGallery(el);
+    });
+  });
+</script>

--- a/src/components/Product/ProductGallery.astro
+++ b/src/components/Product/ProductGallery.astro
@@ -114,6 +114,7 @@ const total = images.length;
             data-gallery-next
             data-dir="next"
             aria-label="Next image"
+            disabled={total <= 1}
           >
             <svg
               viewBox="0 0 24 24"

--- a/src/components/Product/ProductGallery.astro
+++ b/src/components/Product/ProductGallery.astro
@@ -60,7 +60,7 @@ const total = images.length;
                 class="pg-slide w-full min-w-full overflow-hidden md:cursor-zoom-in"
                 role="button"
                 aria-roledescription="slide"
-                aria-label={`${index + 1} / ${total}`}
+                aria-label={`Open image ${index + 1} of ${total}: ${image.alt}`}
                 aria-haspopup="dialog"
                 data-index={index}
                 data-full={image.full || image.src}
@@ -146,7 +146,7 @@ const total = images.length;
                 ]}
                 data-thumb-index={index}
                 aria-pressed={index === 0 ? 'true' : 'false'}
-                aria-label={`Image ${index + 1}`}
+                aria-label={`Image ${index + 1}: ${image.alt}`}
               >
                 <img
                   src={image.thumb || image.src}
@@ -203,7 +203,7 @@ const total = images.length;
                 class="pg-slide w-full min-w-full flex items-center justify-center"
                 role="group"
                 aria-roledescription="slide"
-                aria-label={`${index + 1} / ${total}`}
+                aria-label={`Image ${index + 1} of ${total}: ${image.alt}`}
                 data-index={index}
               >
                 <div class="pg-zoom" data-zoom-container>
@@ -274,7 +274,7 @@ const total = images.length;
                   ]}
                   data-thumb-index={index}
                   aria-pressed={index === 0 ? 'true' : 'false'}
-                  aria-label={`Image ${index + 1}`}
+                  aria-label={`Image ${index + 1}: ${image.alt}`}
                 >
                   <img
                     src={image.thumb || image.src}

--- a/src/components/Product/ProductGallery.astro
+++ b/src/components/Product/ProductGallery.astro
@@ -63,6 +63,7 @@ const total = images.length;
                 aria-label={`${index + 1} / ${total}`}
                 data-index={index}
                 data-full={image.full || image.src}
+                tabindex="0"
               >
                 <img
                   src={image.src}
@@ -88,7 +89,7 @@ const total = images.length;
 
           <button
             type="button"
-            class="pg-arrow hidden md:flex absolute top-50% left-0 z-10 w-10 h-10 items-center justify-center border-none bg-transparent text-primary-400 cursor-pointer drop-shadow-md"
+            class="pg-arrow hidden md:flex absolute top-1/2 left-0 z-10 w-10 h-10 items-center justify-center border-none bg-transparent text-primary-400 cursor-pointer drop-shadow-md"
             data-gallery-prev
             data-dir="prev"
             aria-label="Previous image"
@@ -108,7 +109,7 @@ const total = images.length;
           </button>
           <button
             type="button"
-            class="pg-arrow hidden md:flex absolute top-50% right-0 z-10 w-10 h-10 items-center justify-center border-none bg-transparent text-primary-400 cursor-pointer drop-shadow-md"
+            class="pg-arrow hidden md:flex absolute top-1/2 right-0 z-10 w-10 h-10 items-center justify-center border-none bg-transparent text-primary-400 cursor-pointer drop-shadow-md"
             data-gallery-next
             data-dir="next"
             aria-label="Next image"
@@ -133,7 +134,6 @@ const total = images.length;
           <div
             class="hidden md:flex gap-2 mt-3 pb-[3px] overflow-x-auto scrollbar-none"
             data-gallery-thumbs
-            role="tablist"
             aria-label="Image thumbnails"
           >
             {images.map((image, index) => (
@@ -144,8 +144,7 @@ const total = images.length;
                   { 'is-active': index === 0 },
                 ]}
                 data-thumb-index={index}
-                role="tab"
-                aria-selected={index === 0 ? 'true' : 'false'}
+                aria-pressed={index === 0 ? 'true' : 'false'}
                 aria-label={`Image ${index + 1}`}
               >
                 <img
@@ -210,8 +209,8 @@ const total = images.length;
                   <img
                     src={image.full || image.src}
                     alt={image.alt}
-                    loading={index === 0 ? 'eager' : 'lazy'}
-                    decoding={index === 0 ? 'sync' : 'async'}
+                    loading="lazy"
+                    decoding="async"
                     class="pg-zoom-img"
                     width="1600"
                     height="1200"
@@ -224,7 +223,7 @@ const total = images.length;
 
           <button
             type="button"
-            class="pg-dialog-arrow hidden md:flex absolute top-50% left-3 -translate-y-50% z-10 w-12 h-12 items-center justify-center border-none bg-black/45 text-neutral-400 cursor-pointer rounded transition-colors"
+            class="pg-dialog-arrow hidden md:flex absolute top-1/2 left-3 -translate-y-1/2 z-10 w-12 h-12 items-center justify-center border-none bg-black/45 text-neutral-400 cursor-pointer rounded transition-colors"
             data-dialog-prev
             aria-label="Previous image"
           >
@@ -242,7 +241,7 @@ const total = images.length;
           </button>
           <button
             type="button"
-            class="pg-dialog-arrow hidden md:flex absolute top-50% right-3 -translate-y-50% z-10 w-12 h-12 items-center justify-center border-none bg-black/45 text-neutral-400 cursor-pointer rounded transition-colors"
+            class="pg-dialog-arrow hidden md:flex absolute top-1/2 right-3 -translate-y-1/2 z-10 w-12 h-12 items-center justify-center border-none bg-black/45 text-neutral-400 cursor-pointer rounded transition-colors"
             data-dialog-next
             aria-label="Next image"
           >
@@ -263,7 +262,6 @@ const total = images.length;
             <div
               class="flex shrink-0 gap-1 px-4 py-2 pb-3 justify-center overflow-x-auto scrollbar-none bg-black/80"
               data-dialog-thumbs
-              role="tablist"
               aria-label="Image thumbnails"
             >
               {images.map((image, index) => (
@@ -274,8 +272,7 @@ const total = images.length;
                     { 'is-active': index === 0 },
                   ]}
                   data-thumb-index={index}
-                  role="tab"
-                  aria-selected={index === 0 ? 'true' : 'false'}
+                  aria-pressed={index === 0 ? 'true' : 'false'}
                   aria-label={`Image ${index + 1}`}
                 >
                   <img

--- a/src/components/Product/product-gallery.css
+++ b/src/components/Product/product-gallery.css
@@ -83,7 +83,7 @@
   }
 }
 
-/* ── Zoom (native overflow scroll, no crop) ── */
+/* ── Zoom (transform-origin based, GPU-accelerated) ── */
 
 .pg-zoom {
   @apply flex items-center justify-center overflow-hidden cursor-zoom-in;

--- a/src/components/Product/product-gallery.css
+++ b/src/components/Product/product-gallery.css
@@ -127,3 +127,17 @@
     @apply opacity-30 cursor-default;
   }
 }
+
+/* ── Reduced motion ── */
+
+@media (prefers-reduced-motion: reduce) {
+  .pg-slider,
+  .pg-dialog-slider {
+    scroll-behavior: auto;
+  }
+
+  .pg-arrow,
+  .pg-zoom-img {
+    transition: none;
+  }
+}

--- a/src/components/Product/product-gallery.css
+++ b/src/components/Product/product-gallery.css
@@ -1,0 +1,128 @@
+/**
+ * ProductGallery — only styles that can't be expressed as UnoCSS utilities:
+ * scroll-snap, scrollbar hiding, arrow hover animation, interactive states.
+ */
+
+/* ── Scroll-snap base (slider + dialog slider) ── */
+
+.pg-slider,
+.pg-dialog-slider {
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  img {
+    -webkit-user-drag: none;
+  }
+}
+
+.pg-slide {
+  scroll-snap-align: center;
+}
+
+/* ── Arrow hover reveal animation ── */
+
+.pg-arrow {
+  transition:
+    transform 0.3s ease,
+    opacity 0.2s;
+  will-change: transform;
+
+  &[data-dir='prev'] {
+    transform: translate(-5rem, -50%);
+  }
+  &[data-dir='next'] {
+    transform: translate(5rem, -50%);
+  }
+
+  &:disabled {
+    @apply opacity-30 cursor-default;
+  }
+  &:hover:not(:disabled) {
+    color: var(--clr-primary-500, #0077b3);
+  }
+}
+
+.pg-main:hover {
+  .pg-arrow[data-dir='prev']:not(:disabled) {
+    transform: translate(50%, -50%);
+  }
+  .pg-arrow[data-dir='next']:not(:disabled) {
+    transform: translate(-50%, -50%);
+  }
+}
+
+/* ── Thumbnail active state ── */
+
+.pg-thumb {
+  @apply opacity-60 transition-all duration-200;
+
+  &:hover {
+    @apply opacity-80;
+  }
+  &.is-active {
+    @apply opacity-100;
+    border-color: var(--clr-primary-400, #0099da);
+  }
+}
+
+/* ── Dialog ── */
+
+.pg-dialog {
+  &::backdrop {
+    background: rgb(0 0 0 / 0.95);
+  }
+  &[open] {
+    @apply flex flex-col;
+  }
+}
+
+/* ── Zoom (native overflow scroll, no crop) ── */
+
+.pg-zoom {
+  @apply flex items-center justify-center overflow-hidden cursor-zoom-in;
+  width: 100%;
+  height: 100%;
+
+  &.is-zoomed {
+    @apply cursor-zoom-out;
+  }
+}
+
+.pg-zoom-img {
+  @apply max-w-full max-h-full object-contain select-none;
+  -webkit-user-drag: none;
+  transform-origin: 0 0;
+  transition: transform 0.3s ease;
+  will-change: transform;
+}
+
+/* ── Dialog thumbnail active state ── */
+
+.pg-dialog-thumb {
+  @apply opacity-50 transition-all duration-200;
+
+  &:hover {
+    @apply opacity-75;
+  }
+  &.is-active {
+    @apply opacity-100;
+    border-color: #fff;
+  }
+}
+
+/* ── Dialog arrow hover ── */
+
+.pg-dialog-arrow {
+  &:hover {
+    @apply text-white bg-black/65;
+  }
+  &:disabled {
+    @apply opacity-30 cursor-default;
+  }
+}

--- a/src/components/Product/product-gallery.css
+++ b/src/components/Product/product-gallery.css
@@ -48,7 +48,8 @@
   }
 }
 
-.pg-main:hover {
+.pg-main:hover,
+.pg-main:focus-within {
   .pg-arrow[data-dir='prev']:not(:disabled) {
     transform: translate(50%, -50%);
   }

--- a/src/components/Product/product-gallery.ts
+++ b/src/components/Product/product-gallery.ts
@@ -1,0 +1,500 @@
+/* eslint-disable no-undef */
+/**
+ * ProductGallery — scroll-snap slider + dialog lightbox
+ *
+ * Tiny JS layer (~2-3 KB) on top of CSS scroll-snap:
+ * - IntersectionObserver for active slide tracking
+ * - Thumbnail sync (click → scrollIntoView)
+ * - Arrow navigation (scrollBy)
+ * - Dialog open/close with zoom + pan
+ */
+
+export function initProductGallery(root: HTMLElement) {
+  const slider = root.querySelector<HTMLElement>('[data-gallery-slider]');
+  if (!slider) return;
+
+  const slides = slider.querySelectorAll<HTMLElement>('[data-index]');
+  const totalSlides = slides.length;
+  if (totalSlides === 0) return;
+
+  // Elements
+  const counterCurrent = root.querySelector<HTMLElement>('[data-gallery-current]');
+  const prevBtn = root.querySelector<HTMLButtonElement>('[data-gallery-prev]');
+  const nextBtn = root.querySelector<HTMLButtonElement>('[data-gallery-next]');
+  const thumbsContainer = root.querySelector<HTMLElement>('[data-gallery-thumbs]');
+  const thumbButtons = thumbsContainer?.querySelectorAll<HTMLButtonElement>('[data-thumb-index]');
+
+  // Dialog elements
+  const dialog = root.querySelector<HTMLDialogElement>('[data-gallery-dialog]');
+  const dialogSlider = dialog?.querySelector<HTMLElement>('[data-dialog-slider]');
+  const dialogCurrent = dialog?.querySelector<HTMLElement>('[data-dialog-current]');
+  const dialogClose = dialog?.querySelector<HTMLButtonElement>('[data-dialog-close]');
+  const dialogPrev = dialog?.querySelector<HTMLButtonElement>('[data-dialog-prev]');
+  const dialogNext = dialog?.querySelector<HTMLButtonElement>('[data-dialog-next]');
+  const dialogThumbs = dialog?.querySelectorAll<HTMLButtonElement>('[data-thumb-index]');
+
+  let activeIndex = 0;
+
+  // ── Slide tracking via IntersectionObserver ──
+
+  function createSlideObserver(container: HTMLElement, onActiveChange: (index: number) => void) {
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+            const index = Number((entry.target as HTMLElement).dataset.index);
+            if (!isNaN(index)) onActiveChange(index);
+          }
+        }
+      },
+      { root: container, threshold: 0.5 }
+    );
+
+    container.querySelectorAll<HTMLElement>('[data-index]').forEach(slide => {
+      observer.observe(slide);
+    });
+
+    return observer;
+  }
+
+  // Main slider observer
+  createSlideObserver(slider, index => {
+    activeIndex = index;
+    updateCounter(counterCurrent, index);
+    updateThumbs(thumbButtons, index);
+    updateArrows(prevBtn, nextBtn, index, totalSlides);
+  });
+
+  // ── Counter ──
+
+  function updateCounter(el: HTMLElement | null | undefined, index: number) {
+    if (el) el.textContent = String(index + 1);
+  }
+
+  // ── Thumbnails ──
+
+  function updateThumbs(buttons: NodeListOf<HTMLButtonElement> | undefined, index: number) {
+    if (!buttons) return;
+    buttons.forEach(btn => {
+      const isActive = Number(btn.dataset.thumbIndex) === index;
+      btn.classList.toggle('is-active', isActive);
+      btn.setAttribute('aria-selected', String(isActive));
+      // Scroll active thumb into view
+      if (isActive) {
+        btn.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+      }
+    });
+  }
+
+  function scrollToSlide(container: HTMLElement, index: number) {
+    const slide = container.querySelector<HTMLElement>(`[data-index="${index}"]`);
+    if (slide) {
+      slide.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+  }
+
+  // Thumb clicks → scroll main slider
+  thumbButtons?.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const index = Number(btn.dataset.thumbIndex);
+      scrollToSlide(slider, index);
+    });
+  });
+
+  // ── Mouse drag-to-scroll ──
+
+  initDragScroll(slider);
+  if (thumbsContainer) initDragScroll(thumbsContainer, true);
+
+  // ── Arrow navigation ──
+
+  function updateArrows(
+    prev: HTMLButtonElement | null | undefined,
+    next: HTMLButtonElement | null | undefined,
+    index: number,
+    total: number
+  ) {
+    if (prev) prev.disabled = index === 0;
+    if (next) next.disabled = index === total - 1;
+  }
+
+  prevBtn?.addEventListener('click', () => {
+    scrollToSlide(slider, Math.max(0, activeIndex - 1));
+  });
+
+  nextBtn?.addEventListener('click', () => {
+    scrollToSlide(slider, Math.min(totalSlides - 1, activeIndex + 1));
+  });
+
+  // ── Dialog (fullscreen lightbox) ──
+
+  if (!dialog || !dialogSlider) return;
+
+  let dialogObserver: IntersectionObserver | null = null;
+  let dialogActiveIndex = 0;
+
+  // Open dialog on slide click (but not after drag)
+  slides.forEach(slide => {
+    slide.addEventListener('click', () => {
+      // Skip if this click was the end of a drag gesture
+      if (slider.dataset.wasDragged === '1') return;
+      openDialog(Number(slide.dataset.index));
+    });
+  });
+
+  function preloadDialogImages(centerIndex: number) {
+    if (!dialogSlider) return;
+    // Eagerly load the current, previous, and next full-res images
+    for (let i = centerIndex - 1; i <= centerIndex + 1; i++) {
+      if (i < 0 || i >= totalSlides) continue;
+      const img = dialogSlider.querySelector<HTMLImageElement>(`[data-index="${i}"] [data-zoom-img]`);
+      if (img && img.loading === 'lazy') {
+        img.loading = 'eager';
+      }
+    }
+  }
+
+  function openDialog(startIndex: number) {
+    if (!dialog || !dialogSlider) return;
+
+    dialog.showModal();
+    document.body.style.overflow = 'hidden';
+
+    // Preload full-res images around the starting slide
+    preloadDialogImages(startIndex);
+
+    // Scroll to the clicked image (instant, no animation)
+    const targetSlide = dialogSlider.querySelector<HTMLElement>(`[data-index="${startIndex}"]`);
+    if (targetSlide) {
+      targetSlide.scrollIntoView({ behavior: 'instant' as ScrollBehavior, inline: 'center' });
+    }
+
+    dialogActiveIndex = startIndex;
+    updateCounter(dialogCurrent, startIndex);
+    updateThumbs(dialogThumbs, startIndex);
+    updateArrows(dialogPrev, dialogNext, startIndex, totalSlides);
+
+    // Start observing dialog slides
+    if (!dialogObserver) {
+      dialogObserver = createSlideObserver(dialogSlider, index => {
+        dialogActiveIndex = index;
+        updateCounter(dialogCurrent, index);
+        updateThumbs(dialogThumbs, index);
+        updateArrows(dialogPrev, dialogNext, index, totalSlides);
+        preloadDialogImages(index);
+      });
+    }
+  }
+
+  function closeDialog() {
+    if (!dialog) return;
+
+    // Reset all zoom states
+    dialog.querySelectorAll<HTMLElement>('[data-zoom-container]').forEach(resetZoom);
+
+    // Disconnect slide observer to stop tracking invisible slides
+    if (dialogObserver) {
+      dialogObserver.disconnect();
+      dialogObserver = null;
+    }
+
+    dialog.close();
+    document.body.style.overflow = '';
+
+    // Sync main slider to dialog position
+    scrollToSlide(slider, dialogActiveIndex);
+  }
+
+  dialogClose?.addEventListener('click', closeDialog);
+
+  // Close on backdrop click
+  dialog.addEventListener('click', e => {
+    if (e.target === dialog) closeDialog();
+  });
+
+  // Dialog arrow navigation
+  dialogPrev?.addEventListener('click', () => {
+    scrollToSlide(dialogSlider!, Math.max(0, dialogActiveIndex - 1));
+  });
+
+  dialogNext?.addEventListener('click', () => {
+    scrollToSlide(dialogSlider!, Math.min(totalSlides - 1, dialogActiveIndex + 1));
+  });
+
+  // Dialog thumbnail clicks
+  dialogThumbs?.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const index = Number(btn.dataset.thumbIndex);
+      scrollToSlide(dialogSlider!, index);
+    });
+  });
+
+  // Keyboard navigation in dialog
+  dialog.addEventListener('keydown', e => {
+    if (e.key === 'ArrowLeft') {
+      scrollToSlide(dialogSlider!, Math.max(0, dialogActiveIndex - 1));
+    } else if (e.key === 'ArrowRight') {
+      scrollToSlide(dialogSlider!, Math.min(totalSlides - 1, dialogActiveIndex + 1));
+    }
+  });
+
+  // ── Drag on dialog thumbnails ──
+
+  const dialogThumbsContainer = dialog.querySelector<HTMLElement>('[data-dialog-thumbs]');
+  if (dialogThumbsContainer) initDragScroll(dialogThumbsContainer, true);
+
+  // ── Zoom + Pan ──
+
+  dialog.querySelectorAll<HTMLElement>('[data-zoom-container]').forEach(container => {
+    initZoom(container);
+  });
+}
+
+// ── Mouse drag-to-scroll ──
+// Desktop mouse-drag support. Touch uses native scroll.
+// On release, browser's native scroll-snap handles the snap animation.
+
+function initDragScroll(container: HTMLElement, freeScroll = false) {
+  let isDown = false;
+  let startX = 0;
+  let scrollLeft = 0;
+  let hasMoved = false;
+  let pointerId: number | null = null;
+  let lastX = 0;
+  let lastTime = 0;
+  let velocity = 0;
+
+  function resetStyles() {
+    container.style.cursor = '';
+    container.style.userSelect = '';
+    container.style.scrollBehavior = '';
+    container.style.scrollSnapType = '';
+  }
+
+  // Block native image/link drag inside the container
+  container.addEventListener('dragstart', e => {
+    e.preventDefault();
+  });
+
+  container.addEventListener('pointerdown', e => {
+    if (e.button !== 0 || e.pointerType === 'touch') return;
+
+    isDown = true;
+    hasMoved = false;
+    pointerId = e.pointerId;
+    startX = e.clientX;
+    scrollLeft = container.scrollLeft;
+    lastX = e.clientX;
+    lastTime = Date.now();
+    velocity = 0;
+    container.dataset.wasDragged = '0';
+  });
+
+  container.addEventListener('pointermove', e => {
+    if (!isDown) return;
+
+    const now = Date.now();
+    const dt = now - lastTime;
+    if (dt > 0) velocity = (e.clientX - lastX) / dt;
+    lastX = e.clientX;
+    lastTime = now;
+
+    const walk = e.clientX - startX;
+
+    if (Math.abs(walk) > 5) {
+      if (!hasMoved) {
+        hasMoved = true;
+        // Capture pointer only when actual drag starts
+        container.setPointerCapture(pointerId!);
+        container.style.scrollSnapType = 'none';
+        container.style.scrollBehavior = 'auto';
+        container.style.cursor = 'grabbing';
+        container.style.userSelect = 'none';
+        container.dataset.wasDragged = '1';
+      }
+      container.scrollLeft = scrollLeft - walk;
+    }
+  });
+
+  container.addEventListener('pointerup', () => {
+    if (!isDown) return;
+    isDown = false;
+
+    if (pointerId !== null) {
+      try {
+        container.releasePointerCapture(pointerId);
+      } catch {
+        /* pointer may already be released */
+      }
+      pointerId = null;
+    }
+
+    if (!hasMoved) {
+      resetStyles();
+      return;
+    }
+
+    container.style.cursor = '';
+    container.style.userSelect = '';
+
+    if (freeScroll) {
+      // Free scroll (thumbnails) — just restore styles, stay where released
+      resetStyles();
+    } else {
+      // Snap mode (slides) — snap to nearest or next/prev slide
+      const w = container.clientWidth;
+      const dragDist = container.scrollLeft - scrollLeft;
+      const dragRatio = Math.abs(dragDist) / w;
+      const speed = Math.abs(velocity);
+
+      const shouldChange = dragRatio > 0.15 || speed > 0.3;
+      const currentIndex = Math.round(scrollLeft / w);
+      let targetIndex = currentIndex;
+
+      if (shouldChange) {
+        targetIndex =
+          dragDist > 0
+            ? Math.min(currentIndex + 1, container.children.length - 1)
+            : Math.max(currentIndex - 1, 0);
+      }
+
+      container.style.scrollBehavior = 'smooth';
+      container.scrollLeft = targetIndex * w;
+      setTimeout(resetStyles, 350);
+    }
+  });
+
+  container.addEventListener('pointercancel', () => {
+    isDown = false;
+    hasMoved = false;
+    resetStyles();
+  });
+
+  // Also reset on lostpointercapture as safety net
+  container.addEventListener('lostpointercapture', () => {
+    if (isDown) {
+      isDown = false;
+      hasMoved = false;
+      resetStyles();
+    }
+  });
+
+  // Prevent click after drag
+  container.addEventListener(
+    'click',
+    e => {
+      if (hasMoved) {
+        e.preventDefault();
+        e.stopPropagation();
+        requestAnimationFrame(() => {
+          hasMoved = false;
+        });
+      }
+    },
+    true
+  );
+}
+
+// ── Zoom implementation ──
+// Click to zoom in (scale 2.5x) centered on click point.
+// Mouse-move pans proportionally. Click again to zoom out.
+// GPU-accelerated via transform: scale() + translate().
+
+const ZOOM_SCALE = 2.5;
+
+// WeakMap to store cleanup functions for zoom containers
+const zoomCleanups = new WeakMap<HTMLElement, () => void>();
+
+function initZoom(container: HTMLElement) {
+  const img = container.querySelector<HTMLImageElement>('[data-zoom-img]');
+  if (!img) return;
+
+  let isZoomed = false;
+
+  function zoomIn(clientX: number, clientY: number) {
+    isZoomed = true;
+    container.classList.add('is-zoomed');
+
+    const rect = img.getBoundingClientRect();
+    // Set transform-origin to click point (relative to image)
+    const originX = ((clientX - rect.left) / rect.width) * 100;
+    const originY = ((clientY - rect.top) / rect.height) * 100;
+    img.style.transformOrigin = `${originX}% ${originY}%`;
+    img.style.transform = `scale(${ZOOM_SCALE})`;
+  }
+
+  function zoomOut() {
+    isZoomed = false;
+    container.classList.remove('is-zoomed');
+    img.style.transform = 'scale(1)';
+    container.removeEventListener('mousemove', onMouseMove);
+  }
+
+  // Mouse-move panning: move the transform-origin proportionally to cursor position
+  function onMouseMove(e: MouseEvent) {
+    if (!isZoomed) return;
+    const containerRect = container.getBoundingClientRect();
+    const x = ((e.clientX - containerRect.left) / containerRect.width) * 100;
+    const y = ((e.clientY - containerRect.top) / containerRect.height) * 100;
+    img.style.transformOrigin = `${x}% ${y}%`;
+  }
+
+  // Store cleanup so resetZoom can remove the mousemove listener
+  zoomCleanups.set(container, () => {
+    isZoomed = false;
+    container.removeEventListener('mousemove', onMouseMove);
+  });
+
+  container.addEventListener('click', e => {
+    if (isZoomed) {
+      zoomOut();
+    } else {
+      zoomIn(e.clientX, e.clientY);
+      container.addEventListener('mousemove', onMouseMove);
+    }
+  });
+
+  // Mouse wheel zoom
+  container.addEventListener(
+    'wheel',
+    e => {
+      if (e.deltaY < 0 && !isZoomed) {
+        e.preventDefault();
+        zoomIn(e.clientX, e.clientY);
+        container.addEventListener('mousemove', onMouseMove);
+      } else if (e.deltaY > 0 && isZoomed) {
+        e.preventDefault();
+        zoomOut();
+      }
+    },
+    { passive: false }
+  );
+
+  // Double-tap to zoom (mobile)
+  let lastTap = 0;
+  container.addEventListener(
+    'touchend',
+    e => {
+      const now = Date.now();
+      if (now - lastTap < 300) {
+        e.preventDefault();
+        if (isZoomed) {
+          zoomOut();
+        } else {
+          const touch = e.changedTouches[0];
+          zoomIn(touch.clientX, touch.clientY);
+        }
+      }
+      lastTap = now;
+    },
+    { passive: false }
+  );
+}
+
+function resetZoom(container: HTMLElement) {
+  const img = container.querySelector<HTMLImageElement>('[data-zoom-img]');
+  if (img) img.style.transform = '';
+  container.classList.remove('is-zoomed');
+  // Clean up mousemove listener if zoom was active
+  zoomCleanups.get(container)?.();
+}

--- a/src/components/Product/product-gallery.ts
+++ b/src/components/Product/product-gallery.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 /**
  * ProductGallery — scroll-snap slider + dialog lightbox
  *
@@ -78,7 +77,7 @@ export function initProductGallery(root: HTMLElement) {
     buttons.forEach(btn => {
       const isActive = Number(btn.dataset.thumbIndex) === index;
       btn.classList.toggle('is-active', isActive);
-      btn.setAttribute('aria-selected', String(isActive));
+      btn.setAttribute('aria-pressed', String(isActive));
       // Scroll active thumb into view
       if (isActive) {
         btn.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
@@ -143,13 +142,20 @@ export function initProductGallery(root: HTMLElement) {
 
   let dialogObserver: IntersectionObserver | null = null;
   let dialogActiveIndex = 0;
+  let savedOverflow = '';
 
-  // Open dialog on slide click (but not after drag)
+  // Open dialog on slide click or Enter/Space (but not after drag)
   slides.forEach(slide => {
     slide.addEventListener('click', () => {
       // Skip if this click was the end of a drag gesture
       if (slider.dataset.wasDragged === '1') return;
       openDialog(Number(slide.dataset.index));
+    });
+    slide.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openDialog(Number(slide.dataset.index));
+      }
     });
   });
 
@@ -169,6 +175,7 @@ export function initProductGallery(root: HTMLElement) {
     if (!dialog || !dialogSlider) return;
 
     dialog.showModal();
+    savedOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
 
     // Preload full-res images around the starting slide
@@ -177,7 +184,7 @@ export function initProductGallery(root: HTMLElement) {
     // Scroll to the clicked image (instant, no animation)
     const targetSlide = dialogSlider.querySelector<HTMLElement>(`[data-index="${startIndex}"]`);
     if (targetSlide) {
-      targetSlide.scrollIntoView({ behavior: 'instant' as ScrollBehavior, inline: 'center' });
+      targetSlide.scrollIntoView({ behavior: 'auto', inline: 'center' });
     }
 
     dialogActiveIndex = startIndex;
@@ -197,9 +204,7 @@ export function initProductGallery(root: HTMLElement) {
     }
   }
 
-  function closeDialog() {
-    if (!dialog) return;
-
+  function teardownDialog() {
     // Reset all zoom states
     dialog.querySelectorAll<HTMLElement>('[data-zoom-container]').forEach(resetZoom);
 
@@ -209,12 +214,18 @@ export function initProductGallery(root: HTMLElement) {
       dialogObserver = null;
     }
 
-    dialog.close();
-    document.body.style.overflow = '';
+    document.body.style.overflow = savedOverflow;
 
     // Sync main slider to dialog position
     scrollToSlide(slider, dialogActiveIndex);
   }
+
+  function closeDialog() {
+    if (dialog.open) dialog.close();
+  }
+
+  // Runs on both explicit close and native Escape
+  dialog.addEventListener('close', teardownDialog);
 
   dialogClose?.addEventListener('click', closeDialog);
 
@@ -295,6 +306,11 @@ function initDragScroll(container: HTMLElement, freeScroll = false) {
     isDown = true;
     hasMoved = false;
     pointerId = e.pointerId;
+    try {
+      container.setPointerCapture(pointerId);
+    } catch {
+      /* pointer capture may not be supported */
+    }
     startX = e.clientX;
     scrollLeft = container.scrollLeft;
     lastX = e.clientX;
@@ -317,8 +333,6 @@ function initDragScroll(container: HTMLElement, freeScroll = false) {
     if (Math.abs(walk) > 5) {
       if (!hasMoved) {
         hasMoved = true;
-        // Capture pointer only when actual drag starts
-        container.setPointerCapture(pointerId!);
         container.style.scrollSnapType = 'none';
         container.style.scrollBehavior = 'auto';
         container.style.cursor = 'grabbing';
@@ -458,7 +472,27 @@ function initZoom(container: HTMLElement) {
     container.removeEventListener('mousemove', onMouseMove);
   });
 
+  // Track touch timestamps to avoid touch-generated clicks triggering zoom
+  let lastTouchTime = 0;
+  container.addEventListener(
+    'touchstart',
+    () => {
+      lastTouchTime = Date.now();
+    },
+    { passive: true }
+  );
+  container.addEventListener(
+    'touchend',
+    () => {
+      lastTouchTime = Date.now();
+    },
+    { passive: true }
+  );
+
   container.addEventListener('click', e => {
+    // Ignore touch-generated clicks — mobile uses double-tap instead
+    if (Date.now() - lastTouchTime < 500) return;
+
     if (isZoomed) {
       zoomOut();
     } else {

--- a/src/components/Product/product-gallery.ts
+++ b/src/components/Product/product-gallery.ts
@@ -126,6 +126,17 @@ export function initProductGallery(root: HTMLElement) {
     scrollToSlide(slider, Math.min(totalSlides - 1, activeIndex + 1));
   });
 
+  // Keyboard navigation on main slider
+  slider.addEventListener('keydown', e => {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      scrollToSlide(slider, Math.max(0, activeIndex - 1));
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      scrollToSlide(slider, Math.min(totalSlides - 1, activeIndex + 1));
+    }
+  });
+
   // ── Dialog (fullscreen lightbox) ──
 
   if (!dialog || !dialogSlider) return;
@@ -232,8 +243,10 @@ export function initProductGallery(root: HTMLElement) {
   // Keyboard navigation in dialog
   dialog.addEventListener('keydown', e => {
     if (e.key === 'ArrowLeft') {
+      e.preventDefault();
       scrollToSlide(dialogSlider!, Math.max(0, dialogActiveIndex - 1));
     } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
       scrollToSlide(dialogSlider!, Math.min(totalSlides - 1, dialogActiveIndex + 1));
     }
   });

--- a/src/components/Product/product-gallery.ts
+++ b/src/components/Product/product-gallery.ts
@@ -39,11 +39,19 @@ export function initProductGallery(root: HTMLElement) {
   function createSlideObserver(container: HTMLElement, onActiveChange: (index: number) => void) {
     const observer = new IntersectionObserver(
       entries => {
+        let bestEntry: IntersectionObserverEntry | null = null;
         for (const entry of entries) {
-          if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
-            const index = Number((entry.target as HTMLElement).dataset.index);
-            if (!isNaN(index)) onActiveChange(index);
+          if (
+            entry.isIntersecting &&
+            entry.intersectionRatio >= 0.5 &&
+            (!bestEntry || entry.intersectionRatio > bestEntry.intersectionRatio)
+          ) {
+            bestEntry = entry;
           }
+        }
+        if (bestEntry) {
+          const index = Number((bestEntry.target as HTMLElement).dataset.index);
+          if (!isNaN(index)) onActiveChange(index);
         }
       },
       { root: container, threshold: 0.5 }
@@ -172,7 +180,7 @@ export function initProductGallery(root: HTMLElement) {
   }
 
   function openDialog(startIndex: number) {
-    if (!dialog || !dialogSlider) return;
+    if (!dialog || !dialogSlider || dialog.open) return;
 
     dialog.showModal();
     savedOverflow = document.body.style.overflow;
@@ -438,14 +446,18 @@ function initZoom(container: HTMLElement) {
 
   let isZoomed = false;
 
+  function clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+  }
+
   function zoomIn(clientX: number, clientY: number) {
     isZoomed = true;
     container.classList.add('is-zoomed');
 
     const rect = img.getBoundingClientRect();
-    // Set transform-origin to click point (relative to image)
-    const originX = ((clientX - rect.left) / rect.width) * 100;
-    const originY = ((clientY - rect.top) / rect.height) * 100;
+    // Set transform-origin to click point (relative to image), clamped to 0–100%
+    const originX = clamp(((clientX - rect.left) / rect.width) * 100, 0, 100);
+    const originY = clamp(((clientY - rect.top) / rect.height) * 100, 0, 100);
     img.style.transformOrigin = `${originX}% ${originY}%`;
     img.style.transform = `scale(${ZOOM_SCALE})`;
   }
@@ -460,9 +472,9 @@ function initZoom(container: HTMLElement) {
   // Mouse-move panning: move the transform-origin proportionally to cursor position
   function onMouseMove(e: MouseEvent) {
     if (!isZoomed) return;
-    const containerRect = container.getBoundingClientRect();
-    const x = ((e.clientX - containerRect.left) / containerRect.width) * 100;
-    const y = ((e.clientY - containerRect.top) / containerRect.height) * 100;
+    const rect = img.getBoundingClientRect();
+    const x = clamp(((e.clientX - rect.left) / rect.width) * 100, 0, 100);
+    const y = clamp(((e.clientY - rect.top) / rect.height) * 100, 0, 100);
     img.style.transformOrigin = `${x}% ${y}%`;
   }
 

--- a/src/pages/components/product-gallery.mdx
+++ b/src/pages/components/product-gallery.mdx
@@ -1,0 +1,178 @@
+---
+title: "ProductGallery"
+layout: "../../layouts/MainLayout.astro"
+---
+import ProductGallery from '../../components/Product/ProductGallery.astro'
+
+# ProductGallery
+
+Scroll-snap based product image gallery with fullscreen dialog lightbox. Zero external dependencies — uses CSS scroll-snap, IntersectionObserver, and native `<dialog>`.
+
+**Import** (subpath — has `<script>`, must NOT go in barrel):
+```js
+import ProductGallery from 'spoko-design-system/components/Product/ProductGallery.astro'
+```
+
+## Features
+
+- **Slider** — CSS scroll-snap, swipe on mobile, mouse drag on desktop
+- **Thumbnails** — synced via IntersectionObserver, desktop only
+- **Counter** — fraction (`1/5`), always visible
+- **Arrows** — hover reveal animation, desktop only
+- **Dialog** — fullscreen lightbox with zoom (click/wheel/double-tap) + pan
+- **Keyboard** — ArrowLeft/Right in dialog, Escape to close
+
+## Basic usage
+
+<div class="component-preview">
+  <div class="max-w-xl mx-auto">
+    <ProductGallery
+      images={[
+        { src: "https://placehold.co/800x600/e2e8f0/475569?text=Image+1", thumb: "https://placehold.co/160x120/e2e8f0/475569?text=1", alt: "Product image 1" },
+        { src: "https://placehold.co/800x600/dbeafe/1e40af?text=Image+2", thumb: "https://placehold.co/160x120/dbeafe/1e40af?text=2", alt: "Product image 2" },
+        { src: "https://placehold.co/800x600/dcfce7/166534?text=Image+3", thumb: "https://placehold.co/160x120/dcfce7/166534?text=3", alt: "Product image 3" },
+        { src: "https://placehold.co/800x600/fef3c7/92400e?text=Image+4", thumb: "https://placehold.co/160x120/fef3c7/92400e?text=4", alt: "Product image 4" },
+        { src: "https://placehold.co/800x600/fce7f3/9d174d?text=Image+5", thumb: "https://placehold.co/160x120/fce7f3/9d174d?text=5", alt: "Product image 5" },
+      ]}
+    />
+  </div>
+</div>
+
+```astro
+<ProductGallery
+  images={[
+    { src: "/img/product-1.avif", thumb: "/img/product-1-thumb.avif", full: "/img/product-1-full.jpg", alt: "Product image 1" },
+    { src: "/img/product-2.avif", thumb: "/img/product-2-thumb.avif", full: "/img/product-2-full.jpg", alt: "Product image 2" },
+  ]}
+/>
+```
+
+## Many images (10)
+
+<div class="component-preview">
+  <div class="max-w-xl mx-auto">
+    <ProductGallery
+      images={[
+        { src: "https://placehold.co/800x600/e2e8f0/475569?text=1+of+10", thumb: "https://placehold.co/160x120/e2e8f0/475569?text=1", alt: "Image 1" },
+        { src: "https://placehold.co/800x600/dbeafe/1e40af?text=2+of+10", thumb: "https://placehold.co/160x120/dbeafe/1e40af?text=2", alt: "Image 2" },
+        { src: "https://placehold.co/800x600/dcfce7/166534?text=3+of+10", thumb: "https://placehold.co/160x120/dcfce7/166534?text=3", alt: "Image 3" },
+        { src: "https://placehold.co/800x600/fef3c7/92400e?text=4+of+10", thumb: "https://placehold.co/160x120/fef3c7/92400e?text=4", alt: "Image 4" },
+        { src: "https://placehold.co/800x600/fce7f3/9d174d?text=5+of+10", thumb: "https://placehold.co/160x120/fce7f3/9d174d?text=5", alt: "Image 5" },
+        { src: "https://placehold.co/800x600/e0e7ff/3730a3?text=6+of+10", thumb: "https://placehold.co/160x120/e0e7ff/3730a3?text=6", alt: "Image 6" },
+        { src: "https://placehold.co/800x600/ccfbf1/115e59?text=7+of+10", thumb: "https://placehold.co/160x120/ccfbf1/115e59?text=7", alt: "Image 7" },
+        { src: "https://placehold.co/800x600/fff7ed/9a3412?text=8+of+10", thumb: "https://placehold.co/160x120/fff7ed/9a3412?text=8", alt: "Image 8" },
+        { src: "https://placehold.co/800x600/fdf2f8/831843?text=9+of+10", thumb: "https://placehold.co/160x120/fdf2f8/831843?text=9", alt: "Image 9" },
+        { src: "https://placehold.co/800x600/f5f3ff/4c1d95?text=10+of+10", thumb: "https://placehold.co/160x120/f5f3ff/4c1d95?text=10", alt: "Image 10" },
+      ]}
+    />
+  </div>
+</div>
+
+## With badges slot
+
+<div class="component-preview">
+  <div class="max-w-xl mx-auto">
+    <ProductGallery
+      images={[
+        { src: "https://placehold.co/800x600/e2e8f0/475569?text=With+Badge", thumb: "https://placehold.co/160x120/e2e8f0/475569?text=1", alt: "Product with badge" },
+        { src: "https://placehold.co/800x600/dbeafe/1e40af?text=Image+2", thumb: "https://placehold.co/160x120/dbeafe/1e40af?text=2", alt: "Product image 2" },
+      ]}
+    >
+      <span style="position:absolute;top:8px;left:8px;z-index:10;background:#0099da;color:white;padding:2px 10px;border-radius:2px;font-size:0.75rem;">NEW</span>
+    </ProductGallery>
+  </div>
+</div>
+
+```astro
+<ProductGallery images={images}>
+  <Badges badges={product.badges} class="top-2" />
+</ProductGallery>
+```
+
+## Single image (no thumbnails)
+
+<div class="component-preview">
+  <div class="max-w-xl mx-auto">
+    <ProductGallery
+      images={[
+        { src: "https://placehold.co/800x600/e2e8f0/475569?text=Single+Image", alt: "Single product image" },
+      ]}
+    />
+  </div>
+</div>
+
+## No images (empty state)
+
+<div class="component-preview">
+  <div class="max-w-xl mx-auto">
+    <ProductGallery images={[]} />
+  </div>
+</div>
+
+## Custom aspect ratio
+
+<div class="component-preview">
+  <div class="max-w-xl mx-auto">
+    <ProductGallery
+      aspectRatio="16/9"
+      images={[
+        { src: "https://placehold.co/800x450/e2e8f0/475569?text=16:9", thumb: "https://placehold.co/160x90/e2e8f0/475569?text=1", alt: "Wide image 1" },
+        { src: "https://placehold.co/800x450/dbeafe/1e40af?text=16:9", thumb: "https://placehold.co/160x90/dbeafe/1e40af?text=2", alt: "Wide image 2" },
+      ]}
+    />
+  </div>
+</div>
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `images` | `GalleryImage[]` | `[]` | Array of image objects |
+| `aspectRatio` | `string` | `"4/3"` | CSS aspect-ratio for the slider |
+| `class` | `string` | — | Additional CSS class on root element |
+
+### GalleryImage
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `src` | `string` | yes | Main image URL (used in slider) |
+| `thumb` | `string` | no | Thumbnail URL (falls back to `src`) |
+| `full` | `string` | no | Full resolution URL for dialog (falls back to `src`) |
+| `alt` | `string` | yes | Alt text for the image |
+
+### Slots
+
+| Slot | Description |
+|------|-------------|
+| default | Overlay content (e.g. badges), positioned inside the main slider area |
+| `empty` | Custom content when `images` is empty |
+
+## Integration examples
+
+### catalog.polo.blue
+```astro
+<ProductGallery
+  images={product.images.map((img, i) => ({
+    src: img.avif_1200 || img.webp_1200,
+    thumb: img.avif_320 || img.avif_640,
+    full: img.original || img.url,
+    alt: `${product.number} - ${product.name} [${i + 1}/${product.images.length}]`,
+  }))}
+>
+  <Badges badges={product.badges} class="top-2" />
+</ProductGallery>
+```
+
+### sale.polo.blue
+```astro
+<ProductGallery
+  images={images.map((img, i) => ({
+    src: `/photos/${img.path}`,
+    thumb: `/photos/${img.path}`,
+    full: optimizedImages[i].src,
+    alt: `${productNumber} - ${productTitle} [${i + 1}/${images.length}]`,
+  }))}
+>
+  <Badges badges={badges} class="top-2" />
+</ProductGallery>
+```

--- a/src/pages/components/product-gallery.mdx
+++ b/src/pages/components/product-gallery.mdx
@@ -130,6 +130,7 @@ import ProductGallery from 'spoko-design-system/components/Product/ProductGaller
 | `images` | `GalleryImage[]` | `[]` | Array of image objects |
 | `aspectRatio` | `string` | `"4/3"` | CSS aspect-ratio for the slider |
 | `class` | `string` | — | Additional CSS class on root element |
+| `ariaLabel` | `string` | `"Product image gallery"` | Accessible label for the carousel region |
 
 ### GalleryImage
 

--- a/uno-config/theme/effects.ts
+++ b/uno-config/theme/effects.ts
@@ -11,5 +11,6 @@ export const effects = {
     },
     cursor: {
       'zoom-in': 'zoom-in',
+      'zoom-out': 'zoom-out',
     },
   };


### PR DESCRIPTION
## Summary
- New `ProductGallery` component replacing Swiper + LightGallery with a custom CSS scroll-snap solution (~2-3 KB vs ~68 KB)
- Includes: main slider, thumbnails, fullscreen `<dialog>` with zoom/pan, arrow navigation, fraction counter
- Full accessibility: `aria-roledescription="carousel"`, `aria-pressed` on thumbnail buttons, `aria-live` counters, `prefers-reduced-motion` support
- Shared component for catalog.polo.blue and sale.polo.blue via subpath import

## Test plan
- [ ] Verify slider navigation: drag, arrows, thumbnails, keyboard
- [ ] Test fullscreen dialog: open on click, zoom on click/wheel/double-tap, pan on mousemove
- [ ] Check mobile: swipe, counter, no thumbnails, double-tap zoom
- [ ] Verify edge cases: single image, empty state, many images (10+)
- [ ] Test in catalog.polo.blue and sale.polo.blue integration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a product gallery: CSS scroll‑snap main slider, synchronized thumbnail strip (desktop), slide counters, desktop arrows, fullscreen lightbox with zoom & pan, keyboard & arrow navigation, drag‑to‑scroll, thumbnail syncing, and an empty‑state view.

* **Documentation**
  * Added comprehensive usage docs and examples for the new product gallery component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->