### PR TITLE
fix(ProductGallery): unify arrow navigation style

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />

--- a/src/components/Product/ProductGallery.astro
+++ b/src/components/Product/ProductGallery.astro
@@ -90,7 +90,7 @@ const total = images.length;
 
           <button
             type="button"
-            class="pg-arrow hidden md:flex absolute top-1/2 left-0 z-10 w-10 h-10 items-center justify-center border-none bg-transparent text-primary-400 cursor-pointer drop-shadow-md"
+            class="pg-arrow hidden md:flex absolute top-1/2 left-3 z-10 w-12 h-12 items-center justify-center border-none bg-white/70 text-neutral-600 cursor-pointer rounded transition-colors"
             data-gallery-prev
             data-dir="prev"
             aria-label="Previous image"
@@ -98,8 +98,8 @@ const total = images.length;
           >
             <svg
               viewBox="0 0 24 24"
-              width="22"
-              height="22"
+              width="28"
+              height="28"
               fill="none"
               stroke="currentColor"
               stroke-width="2.5"
@@ -110,7 +110,7 @@ const total = images.length;
           </button>
           <button
             type="button"
-            class="pg-arrow hidden md:flex absolute top-1/2 right-0 z-10 w-10 h-10 items-center justify-center border-none bg-transparent text-primary-400 cursor-pointer drop-shadow-md"
+            class="pg-arrow hidden md:flex absolute top-1/2 right-3 z-10 w-12 h-12 items-center justify-center border-none bg-white/70 text-neutral-600 cursor-pointer rounded transition-colors"
             data-gallery-next
             data-dir="next"
             aria-label="Next image"
@@ -118,8 +118,8 @@ const total = images.length;
           >
             <svg
               viewBox="0 0 24 24"
-              width="22"
-              height="22"
+              width="28"
+              height="28"
               fill="none"
               stroke="currentColor"
               stroke-width="2.5"

--- a/src/components/Product/product-gallery.css
+++ b/src/components/Product/product-gallery.css
@@ -30,7 +30,9 @@
 .pg-arrow {
   transition:
     transform 0.3s ease,
-    opacity 0.2s;
+    opacity 0.2s,
+    background-color 0.2s,
+    color 0.2s;
   will-change: transform;
 
   &[data-dir='prev'] {
@@ -44,17 +46,17 @@
     @apply opacity-30 cursor-default;
   }
   &:hover:not(:disabled) {
-    color: var(--clr-primary-500, #0077b3);
+    @apply bg-white/90 text-neutral-800;
   }
 }
 
 .pg-main:hover,
 .pg-main:focus-within {
   .pg-arrow[data-dir='prev']:not(:disabled) {
-    transform: translate(50%, -50%);
+    transform: translate(0, -50%);
   }
   .pg-arrow[data-dir='next']:not(:disabled) {
-    transform: translate(-50%, -50%);
+    transform: translate(0, -50%);
   }
 }
 

--- a/src/components/Product/product-gallery.ts
+++ b/src/components/Product/product-gallery.ts
@@ -72,6 +72,25 @@ export function initProductGallery(root: HTMLElement) {
     updateArrows(prevBtn, nextBtn, index, totalSlides);
   });
 
+  // Explicit initial state sync — IntersectionObserver fires async and may miss
+  // the first slide if layout isn't ready or scroll position was restored by browser
+  function syncInitialState() {
+    const w = slider.clientWidth;
+    if (w === 0) return; // layout not ready, rAF will retry
+    const index = Math.round(slider.scrollLeft / w);
+    activeIndex = index;
+    updateCounter(counterCurrent, index);
+    updateThumbs(thumbButtons, index);
+    updateArrows(prevBtn, nextBtn, index, totalSlides);
+  }
+
+  // Try sync now, fallback to after layout
+  if (slider.clientWidth > 0) {
+    syncInitialState();
+  } else {
+    requestAnimationFrame(syncInitialState);
+  }
+
   // ── Counter ──
 
   function updateCounter(el: HTMLElement | null | undefined, index: number) {


### PR DESCRIPTION
## Summary
- Align main gallery arrows with dialog/zoom arrows for visual consistency
- Same size (`w-12 h-12`, SVG 28px), rounded shape, semi-transparent background
- Gallery: `bg-white/70` → hover `bg-white/90`, `text-neutral-600` → hover `text-neutral-800`
- Dialog unchanged: `bg-black/45` → hover `bg-black/65`

## Test plan
- [ ] Verify gallery arrows appear on hover (desktop)
- [ ] Verify arrows match zoom/dialog arrows in shape and proportions
- [ ] Test disabled state on first/last image
- [ ] Test keyboard navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated product gallery navigation: larger arrow buttons, shifted horizontal placement, translucent white rounded backgrounds, larger icons, and smoother hover color/background transitions.

* **Bug Fixes**
  * Improved product gallery initial-state synchronization so the displayed slide, counter, and controls correctly reflect the current slider position on load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->