### PR TITLE
fix(ProductGallery): arrow visibility on production

### DIFF
--- a/src/components/Product/product-gallery.css
+++ b/src/components/Product/product-gallery.css
@@ -28,22 +28,15 @@
 /* ── Arrow hover reveal animation ── */
 
 .pg-arrow {
+  transform: translateY(-50%);
+  opacity: 0;
   transition:
-    transform 0.3s ease,
     opacity 0.2s,
     background-color 0.2s,
     color 0.2s;
-  will-change: transform;
-
-  &[data-dir='prev'] {
-    transform: translate(-5rem, -50%);
-  }
-  &[data-dir='next'] {
-    transform: translate(5rem, -50%);
-  }
 
   &:disabled {
-    @apply opacity-30 cursor-default;
+    @apply cursor-default;
   }
   &:hover:not(:disabled) {
     @apply bg-white/90 text-neutral-800;
@@ -52,11 +45,11 @@
 
 .pg-main:hover,
 .pg-main:focus-within {
-  .pg-arrow[data-dir='prev']:not(:disabled) {
-    transform: translate(0, -50%);
+  .pg-arrow:not(:disabled) {
+    opacity: 1;
   }
-  .pg-arrow[data-dir='next']:not(:disabled) {
-    transform: translate(0, -50%);
+  .pg-arrow:disabled {
+    opacity: 0.3;
   }
 }
 


### PR DESCRIPTION
## Summary
- Switch arrow reveal from translate (clipped by `overflow:hidden`) to opacity fade
- Arrows were invisible on prod because `.pg-main` has `overflow:hidden` which clips elements translated outside bounds

## Root cause
Arrows started at `translate(±5rem, -50%)` — pushed 80px outside the container. With `overflow:hidden` on `.pg-main`, they were clipped. On hover they animated back, but the browser never rendered them during the transition because they started outside the clipping region.

## Test plan
- [ ] Verify arrows appear on hover over gallery (desktop)
- [ ] Verify arrows fade in/out smoothly
- [ ] Verify disabled state (first/last image)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced product gallery navigation arrow visibility and interaction behavior during hover.
  * Improved visual feedback for disabled navigation controls with refined appearance.
  * Optimized arrow animations and transitions for smoother gallery browsing.

* **Performance**
  * Streamlined CSS properties to reduce rendering overhead during gallery interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->