### PR TITLE
fix: remove global scroll-behavior: smooth

### DIFF
--- a/.astro/content.d.ts
+++ b/.astro/content.d.ts
@@ -205,6 +205,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("../src/content.config.mjs");
+	export type ContentConfig = typeof import("./../src/content.config.mjs");
 	export type LiveContentConfig = never;
 }

--- a/src/styles/base/base.css
+++ b/src/styles/base/base.css
@@ -77,10 +77,6 @@ code {
   @apply font-novamono;
 }
 
-html {
-  scroll-behavior: smooth;
-}
-
 .swiper-horizontal {
   & > .swiper-scrollbar {
     height: 1px;


### PR DESCRIPTION
## Summary
- Remove `html { scroll-behavior: smooth; }` from base.css
- This causes visible scroll jumps during Astro View Transitions (ClientRouter animates scroll-to-top instead of instant reset)
- Carousel/gallery components already set `scroll-behavior: smooth` on their own containers

## Test plan
- [ ] Navigate between product pages using prev/next — no scroll jump
- [ ] Anchor links still work (no smooth scroll on html, but anchors use browser default)
- [ ] Gallery slider still scrolls smoothly (has its own scroll-behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed smooth scrolling behavior, reverting to standard browser scroll functionality for page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->