### PR TITLE
fix: scope scrollbar styles to body only

### DIFF
--- a/src/layouts/partials/HeadCommon.astro
+++ b/src/layouts/partials/HeadCommon.astro
@@ -39,5 +39,23 @@ import { pwaInfo } from 'virtual:pwa-info';
   gtag('config', '');
 </script> -->
 
+<style is:inline>
+  body {
+    scrollbar-width: thin;
+    scrollbar-color: oklch(65% 0.143 238) oklch(0% 0 0 / 0.1);
+    scrollbar-gutter: stable;
+  }
+  body::-webkit-scrollbar {
+    width: 5px;
+    height: 3px;
+  }
+  body::-webkit-scrollbar-track {
+    background: rgba(0, 0, 0, 0.1);
+  }
+  body::-webkit-scrollbar-thumb {
+    background-color: oklch(65% 0.143 238);
+  }
+</style>
+
 <ClientRouter />
 {pwaInfo && <Fragment set:html={pwaInfo.webManifest.linkTag} />}

--- a/src/layouts/partials/HeadCommon.astro
+++ b/src/layouts/partials/HeadCommon.astro
@@ -40,7 +40,7 @@ import { pwaInfo } from 'virtual:pwa-info';
 </script> -->
 
 <style is:inline>
-  body {
+  :root {
     scrollbar-width: thin;
     scrollbar-color: oklch(65% 0.143 238) oklch(0% 0 0 / 0.1);
     scrollbar-gutter: stable;

--- a/src/styles/base/base.css
+++ b/src/styles/base/base.css
@@ -20,36 +20,6 @@ body {
   overflow-x: hidden;
 }
 
-/*
-    Chrome 121 added support for scrollbar-width and scrollbar-color.
-    If you have scrollbar-width it will disable the --webkit-scrollbar pseudo elements.
-    https://developer.chrome.com/blog/new-in-chrome-121
-    https://developer.chrome.com/docs/css-ui/scrollbar-styling
-    https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar
-*/
-body::-webkit-scrollbar {
-  width: 5px;
-  height: 3px;
-}
-
-body::-webkit-scrollbar-track {
-  @apply bg-black/10;
-  border-radius: 0;
-}
-
-body::-webkit-scrollbar-thumb {
-  border-radius: 0;
-  @apply bg-accent-light;
-}
-
-/* Fallback to browsers without webkit-scrollbar support */
-@supports not selector(::-webkit-scrollbar) {
-  body {
-    scrollbar-width: thin;
-    scrollbar-color: oklch(65% 0.143 238) oklch(0% 0 0 / 0.1);
-  }
-}
-
 *:focus {
   outline: none !important;
 }

--- a/src/styles/base/base.css
+++ b/src/styles/base/base.css
@@ -27,24 +27,24 @@ body {
     https://developer.chrome.com/docs/css-ui/scrollbar-styling
     https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar
 */
-::-webkit-scrollbar {
+body::-webkit-scrollbar {
   width: 5px;
   height: 3px;
 }
 
-::-webkit-scrollbar-track {
+body::-webkit-scrollbar-track {
   @apply bg-black/10;
   border-radius: 0;
 }
 
-::-webkit-scrollbar-thumb {
+body::-webkit-scrollbar-thumb {
   border-radius: 0;
   @apply bg-accent-light;
 }
 
 /* Fallback to browsers without webkit-scrollbar support */
 @supports not selector(::-webkit-scrollbar) {
-  * {
+  body {
     scrollbar-width: thin;
     scrollbar-color: oklch(65% 0.143 238) oklch(0% 0 0 / 0.1);
   }


### PR DESCRIPTION
## Summary
- Change `::-webkit-scrollbar` to `body::-webkit-scrollbar` in base.css
- Change `* { scrollbar-width: thin }` to `body { scrollbar-width: thin }` in fallback
- Global scrollbar styles were overriding `scrollbar-none` on gallery thumbnails

## Test plan
- [ ] Page scrollbar still thin and blue
- [ ] Gallery thumbnails have no visible scrollbar (scrollbar-none works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized scrollbar styling so page scrollbars are now configured in one place.
* **Style**
  * Updated global scrollbar appearance (thinner track, new thumb/track colors) and removed previous duplicated global rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->