### PR TITLE
feat: video link tiles with thumbnails in ProductDetailsList

### DIFF
--- a/src/components/ProductDetailsList.vue
+++ b/src/components/ProductDetailsList.vue
@@ -69,6 +69,27 @@ const getLinkIconClass = (linkType: string) => {
   }
 };
 
+// Extract YouTube video ID from URL
+const getYoutubeVideoId = (url: string): string | null => {
+  const match = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|shorts\/))([a-zA-Z0-9_-]{11})/);
+  return match ? match[1] : null;
+};
+
+// Check if a grouped links item contains video links (YouTube or Vimeo)
+const isVideoLinks = (item: TableItem) => {
+  return item.type === 'links' && (item.id === 'youtube' || item.id === 'vimeo') && Array.isArray(item.value);
+};
+
+// Get thumbnail URL for a video link
+const getVideoThumbnail = (link: Link): string | null => {
+  if (link.type === 'youtube') {
+    const videoId = getYoutubeVideoId(link.url);
+    return videoId ? `https://img.youtube.com/vi/${videoId}/mqdefault.jpg` : null;
+  }
+  // Vimeo thumbnails require API call — not available client-side
+  return null;
+};
+
 // Validate items
 const validatedItems = computed(() => {
   if (!Array.isArray(props.items)) {
@@ -94,18 +115,48 @@ const validatedItems = computed(() => {
       <tr v-for="(row, index) in validatedItems" :key="index" class="details-table-row">
         <ProductDetailName as="th" :text="getHeaderText(row)" class="details-table-header" />
 
-        <!-- Links Array -->
-        <td v-if="isLinksArray(row)" class="details-table-cell">
+        <!-- Video Links (YouTube/Vimeo) as tiles with thumbnails -->
+        <td v-if="isVideoLinks(row)" class="details-table-cell">
+          <div class="flex flex-col gap-3">
+            <a
+              v-for="(link, linkIndex) in row.value as Link[]"
+              :key="linkIndex"
+              :href="link.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="flex items-start gap-3 no-underline text-inherit hover:text-[var(--clr-primary-400,#0099da)] group"
+            >
+              <div class="relative flex-shrink-0 w-28 aspect-video overflow-hidden bg-gray-100 rounded">
+                <img
+                  v-if="getVideoThumbnail(link)"
+                  :src="getVideoThumbnail(link)!"
+                  :alt="link.anchor"
+                  width="240"
+                  height="180"
+                  loading="lazy"
+                  class="w-full h-full object-cover"
+                />
+                <span class="i-lucide-play absolute inset-0 m-auto w-7 h-7 text-white drop-shadow-lg" />
+              </div>
+              <span class="text-sm leading-snug pt-0.5 transition-colors duration-150">
+                {{ link.anchor }}
+              </span>
+            </a>
+          </div>
+        </td>
+
+        <!-- Other Links Array (blog, etc.) -->
+        <td v-else-if="isLinksArray(row)" class="details-table-cell">
           <ul class="list-none p-0 m-0">
             <li
               v-for="(link, linkIndex) in row.value as Link[]"
               :key="linkIndex"
-              class="mb-2 last:mb-0 flex items-center"
+              class="mb-2 last:mb-0 flex items-start"
             >
               <span
                 :class="[
                   getLinkIconClass(link.type),
-                  'leading-none inline-block mr-2 w-4 min-w-4 h-4 text-gray-400',
+                  'leading-none inline-block mr-2 w-4 min-w-4 h-4 text-gray-400 flex-shrink-0 mt-0.5',
                 ]"
               />
               <a :href="link.url" target="_blank" rel="noopener noreferrer" class="link-primary">
@@ -117,11 +168,11 @@ const validatedItems = computed(() => {
 
         <!-- Individual Link (flat format: id=blog/youtube/vimeo, value=url, name=anchor) -->
         <td v-else-if="isIndividualLink(row)" class="details-table-cell">
-          <div class="flex items-center">
+          <div class="flex items-start">
             <span
               :class="[
                 getLinkIconClass(row.id),
-                'leading-none inline-block mr-2 w-4 min-w-4 h-4 text-gray-400',
+                'leading-none inline-block mr-2 w-4 min-w-4 h-4 text-gray-400 flex-shrink-0 mt-0.5',
               ]"
             />
             <a :href="row.value as string" target="_blank" rel="noopener noreferrer" class="link-primary">


### PR DESCRIPTION
## Summary
- YouTube/Vimeo links in `ProductDetailsList` rendered as tiles with thumbnail image and play icon overlay
- YouTube thumbnails auto-generated from video ID (`img.youtube.com/vi/{id}/mqdefault.jpg`)
- Vimeo tiles show play icon on gray background (thumbnails require API call, not available client-side)
- Blog and other links: fixed icon alignment — `items-start` + `mt-0.5` so icons stay at first line when text wraps
- Same fix applied to individual link format (`type: "link"`)

## Test plan
- [ ] Product with YouTube links shows tiles with thumbnails and play icon
- [ ] Product with blog links shows icon aligned to first line of text
- [ ] Clicking tile opens YouTube video in new tab
- [ ] Vimeo links show tile with play icon (no thumbnail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video links in product details now display as interactive thumbnail tiles with play icons instead of text-only list items, providing a better visual preview.

* **Style**
  * Improved layout alignment and icon positioning for product detail rows for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->