### PR TITLE
fix: add gap to tooltip header for series badge spacing

### DIFF
--- a/src/styles/tippy-theme.css
+++ b/src/styles/tippy-theme.css
@@ -51,6 +51,7 @@
 .tippy-box[data-theme~='sds'] .tooltip-header {
   display: flex;
   align-items: center;
+  gap: 0.5rem;
   padding: 0.375rem 0.5rem;
   background-color: #001e50;
   border-radius: 0.5rem 0.5rem 0 0;


### PR DESCRIPTION
## Summary
Add `gap: 0.5rem` to `.tooltip-header` flex container so the series badge (e.g. "EA113") doesn't touch the info text (e.g. "R WRC Street").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in tooltip headers for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->