### PR TITLE
fix: tooltip listeners lost after Astro View Transitions

### DIFF
--- a/src/scripts/tooltips.ts
+++ b/src/scripts/tooltips.ts
@@ -2,7 +2,7 @@
  * SDS Tooltip Engine
  * Powered by Floating UI — replaces tippy.js
  *
- * Uses event delegation on document.body for performance.
+ * Uses event delegation on document (capture phase) for performance.
  * Handles tooltips for any element with [data-sds-tooltip] attribute.
  *
  * Supported attributes:
@@ -203,10 +203,13 @@ export function initTooltips() {
   if (initialized) return;
   initialized = true;
 
-  document.body.addEventListener('mouseenter', handleMouseEnter, true);
-  document.body.addEventListener('mouseleave', handleMouseLeave, true);
-  document.body.addEventListener('focusin', handleFocusIn, true);
-  document.body.addEventListener('focusout', handleFocusOut, true);
+  // Use `document` instead of `document.body` — Astro View Transitions
+  // replace the <body> element during swap, which would lose listeners.
+  // `document` persists across navigations.
+  document.addEventListener('mouseenter', handleMouseEnter, true);
+  document.addEventListener('mouseleave', handleMouseLeave, true);
+  document.addEventListener('focusin', handleFocusIn, true);
+  document.addEventListener('focusout', handleFocusOut, true);
 }
 
 function cleanup() {


### PR DESCRIPTION
## Problem

Tooltips only work on initial page load. After navigating via Astro View Transitions, tooltips stop working entirely — requires full page refresh.

## Root cause

Event listeners were attached to `document.body`. Astro View Transitions **replace the `<body>` element** during page swap, destroying all listeners attached to it. Since `initialized` flag was `true`, listeners were never re-attached.

## Fix

Attach listeners to `document` instead of `document.body`. The `document` object persists across View Transitions navigations, so listeners survive the body swap.

## Test plan

- [ ] Tooltips work on initial page load
- [ ] Navigate to another product page via View Transitions → tooltips still work
- [ ] Navigate back → tooltips still work
- [ ] Full page refresh → tooltips work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced tooltip behavior to properly handle interactions during page navigation and content updates, ensuring tooltips function correctly even when the page structure changes dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->