### PR TITLE
style: refine tooltip visuals

### DIFF
--- a/src/scripts/tooltips.ts
+++ b/src/scripts/tooltips.ts
@@ -16,7 +16,7 @@ import '../styles/sds-tooltip.css';
 
 const SELECTOR = '[data-sds-tooltip]';
 const OFFSET = 8;
-const ARROW_SIZE = 8;
+const ARROW_SIZE = 13;
 const SHIFT_PADDING = 5;
 const SHOW_DELAY = 80;
 const HIDE_DELAY = 60;

--- a/src/styles/sds-tooltip.css
+++ b/src/styles/sds-tooltip.css
@@ -15,12 +15,12 @@
   color: #1e293b; /* slate-darkest */
   font-size: 0.75rem;
   line-height: 1.5;
-  border-radius: 0.5rem;
+  border-radius: 2px;
   box-shadow:
-    0 10px 15px -3px rgb(0 0 0 / 0.1),
-    0 4px 6px -4px rgb(0 0 0 / 0.1);
+    0 30px 90px -20px rgba(0, 0, 0, 0.3),
+    0 0 0 1px #eaecf0;
   max-width: 280px;
-  border: 1px solid #e5e7eb; /* neutral-lighter */
+  margin: 3px 0;
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.15s ease-out;
@@ -42,10 +42,10 @@
 /* Arrow */
 .sds-tooltip-arrow {
   position: absolute;
-  width: 8px;
-  height: 8px;
-  background-color: #f3f4f6; /* neutral-lightest */
-  border: 1px solid #e5e7eb; /* neutral-lighter */
+  width: 13px;
+  height: 13px;
+  background-color: inherit;
+  border: 1px solid #eaecf0;
   transform: rotate(45deg);
 }
 
@@ -74,7 +74,7 @@
   padding: 0.5rem 0.75rem;
   color: #1e293b; /* slate-darkest */
   overflow: hidden;
-  border-radius: 0.5rem;
+  border-radius: 2px;
 }
 
 /* Remove padding for structured tooltips (with tooltip-header) */
@@ -94,7 +94,7 @@
   gap: 0.5rem;
   padding: 0.375rem 0.5rem;
   background-color: #001e50;
-  border-radius: 0.5rem 0.5rem 0 0;
+  border-radius: 2px 2px 0 0;
   color: white;
 }
 


### PR DESCRIPTION
## Summary

Visual refinements to tooltip styling, tested on catalog.polo.blue.

- Border-radius: `0.5rem` → `2px` (sharper corners)
- Shadow: Wikipedia-style (`0 30px 90px -20px rgba(0,0,0,0.3)` + `0 0 0 1px #eaecf0`)
- Arrow: `8px` → `13px` with matching border, inherits background color
- Margin: `3px` spacing between trigger and tooltip
- Border removed (replaced by box-shadow outline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced tooltip appearance with increased arrow sizing for improved visibility, updated border radius from 0.5rem to 2px for a more contemporary look, refined shadow effects with added outline styling, and adjusted margin spacing for better layout balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->