### PR TITLE
feat: add tooltip UnoCSS shortcuts

### DIFF
--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -1,9 +1,10 @@
 // shortcuts/components.ts
-import { 
-  COLORS, 
-  IMAGE_STYLES, 
-  LAYOUT, 
+import {
+  COLORS,
+  IMAGE_STYLES,
+  LAYOUT,
   TRANSITIONS,
+  TOOLTIP_STYLES,
   PRODUCT_STYLES,
   aspectRatios
 } from './constants'
@@ -22,6 +23,8 @@ export const componentShortcuts = [
   ['p-number', `${LAYOUT.flex.base} leading-none relative`],
   ['tooltip', 'invisible absolute'],
   ['has-tooltip', 'hover:(visible z-50)'],
+  ['tooltip-box', TOOLTIP_STYLES.box],
+  ['tooltip-trigger', TOOLTIP_STYLES.trigger],
   ['product-code', 'text-blue-light mr-1 leading-none tracking-wide select-all'],
   ['product-info', 'text-slate-light text-xxs font-textlight leading-none mt-0.5 md:(mt-0 text-xs)'],
   ['product-date', 'inline-block text-xxs md:text-xs leading-none mt-1 md:(mt-4 mb-1) mr-2'],
@@ -93,7 +96,7 @@ export const componentShortcuts = [
   ['product-thumb--tile', `w-full h-auto ${IMAGE_STYLES.objectContain} object-top bg-gray-100 ${aspectRatios['4/3']} ${LAYOUT.position.relative}`],
   ['product-thumb--carousel', `w-60 min-w-60 sm:w-22 sm:min-w-22 xl:w-30 xl:min-w-30 h-auto ${IMAGE_STYLES.objectContain} object-top bg-gray-100 ${aspectRatios['4/3']} ${LAYOUT.position.relative}`],
 
-  
+
   // FeaturesList component
   ['features-list', 'mb-6'],
   ['features-list-item', 'leading-5 relative mb-2'],

--- a/uno-config/theme/shortcuts/constants.ts
+++ b/uno-config/theme/shortcuts/constants.ts
@@ -105,9 +105,9 @@ export const BUTTON_STYLES = {
 // Common typography styles
 export const TYPOGRAPHY = {
   headline: {
-    base: 'font-headregular',        
+    base: 'font-headregular',
     bold: 'font-headbold',           // dedykowany font bold
-    light: 'font-headlight',         
+    light: 'font-headlight',
     lightBold: 'font-headlight font-bold',  // light font + CSS bold
     lightThin: 'font-headlight font-300 tracking-tight',  // light + thin + tracking
     // base: 'font-headregular',
@@ -115,9 +115,9 @@ export const TYPOGRAPHY = {
     // light: 'font-headlight font-300 tracking-tight',
   },
   text: {
-    light: 'font-textlight',         
-    regular: 'font-textregular',     
-    bold: 'font-textbold',           
+    light: 'font-textlight',
+    regular: 'font-textregular',
+    bold: 'font-textbold',
     lightBold: 'font-textlight font-bold',  // light font + CSS bold
     lightThin: 'font-textlight font-300 tracking-tight',  // light + th
     xs: 'text-3',
@@ -125,6 +125,12 @@ export const TYPOGRAPHY = {
     base: 'text-4',
     lg: 'text-4.5',
   },
+} as const
+
+// Tooltip styles
+export const TOOLTIP_STYLES = {
+  box: 'bg-neutral-lightest text-slate-darkest text-xs whitespace-nowrap',
+  trigger: 'underline decoration-dotted underline-offset-4 decoration-neutral-light cursor-default transition-colors duration-200 hover:decoration-blue-darker',
 } as const
 
 // Product specific styles (merged PRODUCT_STYLES and PRODUCT_CONSTANTS)


### PR DESCRIPTION
## Summary

Add reusable UnoCSS shortcuts for tooltip styling — enables consistent tooltip appearance across components without duplicating CSS.

## New shortcuts

| Shortcut | Classes | Usage |
|---|---|---|
| `tooltip-box` | `bg-neutral-lightest text-slate-darkest text-xs whitespace-nowrap` | Tooltip content styling |
| `tooltip-trigger` | `underline decoration-dotted underline-offset-4 decoration-neutral-light cursor-default transition-colors duration-200 hover:decoration-blue-darker` | Elements that trigger tooltips |

## Usage

```html
<!-- CSS-only tooltip (like ButtonCopy) -->
<span class="tooltip tooltip-box">Copy</span>

<!-- Tooltip trigger (like manufacturer name, engine code) -->
<span class="tooltip-trigger" data-sds-tooltip="...">GEBRA GmbH</span>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltip styling support with new utility shortcuts for customizing tooltip box and trigger components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->