### PR TITLE
feat: add updateTooltipContent export and migrate ButtonCopy to SDS tooltip

### DIFF
--- a/src/components/ButtonCopy.astro
+++ b/src/components/ButtonCopy.astro
@@ -84,8 +84,10 @@ const COPY_ICON = `url("data:image/svg+xml;utf8,${encodeURIComponent(
     private updateTooltip(): void {
       if (this.resetTimer) clearTimeout(this.resetTimer);
       updateTooltipContent(this.button, this.copiedText);
+      this.button.setAttribute('aria-label', this.copiedText);
       this.resetTimer = setTimeout(() => {
         updateTooltipContent(this.button, this.originalText);
+        this.button.setAttribute('aria-label', this.originalText);
         this.resetTimer = null;
       }, ClipboardButton.COPY_TIMEOUT);
     }

--- a/src/components/ButtonCopy.astro
+++ b/src/components/ButtonCopy.astro
@@ -1,14 +1,13 @@
 ---
 interface Props {
   productNumber: string;
-  tooltipClasses?: string;
   texts: {
     copy: string;
     copied: string;
   };
 }
 
-const { productNumber, tooltipClasses = '', texts } = Astro.props;
+const { productNumber, texts } = Astro.props;
 
 // SVG icon as data URL for mask
 const COPY_ICON = `url("data:image/svg+xml;utf8,${encodeURIComponent(
@@ -18,31 +17,30 @@ const COPY_ICON = `url("data:image/svg+xml;utf8,${encodeURIComponent(
 
 <button
   aria-label={texts.copy}
-  class="btn-copy has-tooltip"
+  class="btn-copy"
   data-copy-text={productNumber}
   data-category={Astro.url.pathname.split('/')[1] || ''}
+  data-sds-tooltip={texts.copy}
+  data-copy-original-tooltip={texts.copy}
+  data-copy-copied-tooltip={texts.copied}
 >
-  <span
-    class:list={['tooltip rounded-full btn-copy-text', tooltipClasses]}
-    data-text={texts.copy}
-    data-copied-text={texts.copied}></span>
   <span class="copy-icon" role="img" aria-hidden="true"></span>
 </button>
 
 <script>
+  import { updateTooltipContent } from '../scripts/tooltips';
+
   class ClipboardButton {
     private static readonly COPY_TIMEOUT = 2000;
     private static readonly ANALYTICS_EVENT = 'product_code_copy';
     private readonly originalText: string;
+    private readonly copiedText: string;
     private resetTimer: ReturnType<typeof setTimeout> | null = null;
 
     constructor(private button: HTMLButtonElement) {
-      this.originalText = this.tooltip?.dataset.text || 'Copy';
+      this.originalText = button.dataset.copyOriginalTooltip || 'Copy';
+      this.copiedText = button.dataset.copyCopiedTooltip || 'Copied';
       this.button.addEventListener('click', () => this.handleCopy());
-    }
-
-    private get tooltip(): HTMLSpanElement {
-      return this.button.querySelector('.tooltip') as HTMLSpanElement;
     }
 
     private get copyText(): string {
@@ -51,10 +49,6 @@ const COPY_ICON = `url("data:image/svg+xml;utf8,${encodeURIComponent(
 
     private get category(): string {
       return this.button.dataset.category || '';
-    }
-
-    private get copiedText(): string {
-      return this.tooltip.dataset.copiedText || 'Copied';
     }
 
     private async handleCopy(): Promise<void> {
@@ -89,9 +83,9 @@ const COPY_ICON = `url("data:image/svg+xml;utf8,${encodeURIComponent(
 
     private updateTooltip(): void {
       if (this.resetTimer) clearTimeout(this.resetTimer);
-      this.tooltip.dataset.text = this.copiedText;
+      updateTooltipContent(this.button, this.copiedText);
       this.resetTimer = setTimeout(() => {
-        this.tooltip.dataset.text = this.originalText;
+        updateTooltipContent(this.button, this.originalText);
         this.resetTimer = null;
       }, ClipboardButton.COPY_TIMEOUT);
     }
@@ -149,18 +143,6 @@ const COPY_ICON = `url("data:image/svg+xml;utf8,${encodeURIComponent(
     .btn-copy {
       right: -1.25rem;
     }
-  }
-
-  .tooltip {
-    @apply invisible absolute -top-8 left-1/2 -translate-x-1/2 bg-neutral px-2 py-1 text-xs text-white opacity-0 transition-opacity;
-  }
-
-  .tooltip::before {
-    content: attr(data-text);
-  }
-
-  .has-tooltip:hover .tooltip {
-    @apply visible opacity-100;
   }
 
   .copy-icon {

--- a/src/scripts/tooltips.ts
+++ b/src/scripts/tooltips.ts
@@ -144,6 +144,17 @@ export function showTooltip(target: HTMLElement) {
   });
 }
 
+/**
+ * Update tooltip content for a target element.
+ * If the tooltip is currently visible for this target, updates the displayed content immediately.
+ */
+export function updateTooltipContent(target: HTMLElement, html: string) {
+  target.setAttribute('data-sds-tooltip', html);
+  if (currentTarget === target && contentEl) {
+    contentEl.innerHTML = html;
+  }
+}
+
 export function hideTooltip() {
   if (!tooltipEl || !currentTarget) return;
 


### PR DESCRIPTION
## Summary
- Export `updateTooltipContent()` from `tooltips.ts` for dynamic tooltip content updates (e.g., "Copy" → "Copied" feedback)
- Migrate `ButtonCopy.astro` from custom CSS tooltip (`has-tooltip` + `.tooltip`) to `data-sds-tooltip` system
- Remove old `.tooltip`, `.has-tooltip:hover .tooltip` CSS and unused `tooltipClasses` prop
- Ensures all SDS tooltips use unified Floating UI styling (arrow, shadow, background)

## Test plan
- [ ] Verify ButtonCopy tooltip shows with SDS styling (arrow, shadow, `#f3f4f6` bg)
- [ ] Verify "Copied" feedback updates tooltip text in-place after click
- [ ] Verify tooltip reverts to "Copy" after 2 seconds
- [ ] Verify no regression on other SDS tooltips (PrCode, ProductEngine, manufacturer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the copy button’s tooltip implementation: the button now embeds tooltip text via data attributes and updates its aria-label to reflect copy/reset states.
  * Removed the separate tooltip element and related styling, reducing DOM complexity while preserving copy feedback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->