### PR TITLE
style: change tooltip background from gray to white

### DIFF
--- a/src/components/PrCode.vue
+++ b/src/components/PrCode.vue
@@ -35,6 +35,7 @@ defineProps({
       { 'btn-prcode--pdp': isPdp },
     ]"
     :data-sds-tooltip="prcode.description || undefined"
+    data-sds-tooltip-offset="12"
   >
     {{ prcode.code }}
   </span>

--- a/src/scripts/tooltips.ts
+++ b/src/scripts/tooltips.ts
@@ -8,6 +8,7 @@
  * Supported attributes:
  * - data-sds-tooltip             — HTML content to display
  * - data-sds-tooltip-placement   — placement override (default: 'top')
+ * - data-sds-tooltip-offset      — distance in px between trigger and tooltip (default: 8)
  * - data-sds-tooltip-interactive — allow hovering over tooltip (for clickable links)
  */
 
@@ -59,6 +60,13 @@ function getPlacement(target: HTMLElement): Placement {
   return attr && VALID_PLACEMENTS.has(attr as Placement) ? (attr as Placement) : 'top';
 }
 
+function getOffset(target: HTMLElement): number {
+  const attr = target.getAttribute('data-sds-tooltip-offset');
+  if (!attr) return OFFSET;
+  const val = parseInt(attr, 10);
+  return Number.isFinite(val) ? val : OFFSET;
+}
+
 function getOrCreateTooltip(): {
   tooltip: HTMLElement;
   arrow: HTMLElement;
@@ -84,10 +92,16 @@ function getOrCreateTooltip(): {
 
 function updatePosition(target: HTMLElement, tooltip: HTMLElement, arrowElement: HTMLElement) {
   const placement = getPlacement(target);
+  const offsetPx = getOffset(target);
 
   computePosition(target, tooltip, {
     placement,
-    middleware: [offset(OFFSET), flip(), shift({ padding: SHIFT_PADDING }), arrow({ element: arrowElement })],
+    middleware: [
+      offset(offsetPx),
+      flip(),
+      shift({ padding: SHIFT_PADDING }),
+      arrow({ element: arrowElement }),
+    ],
   }).then(({ x, y, placement: finalPlacement, middlewareData }) => {
     Object.assign(tooltip.style, {
       left: `${x}px`,

--- a/src/styles/sds-tooltip.css
+++ b/src/styles/sds-tooltip.css
@@ -11,7 +11,7 @@
   left: 0;
   width: max-content;
   z-index: 9999;
-  background-color: #f3f4f6; /* neutral-lightest */
+  background-color: #ffffff;
   color: #1e293b; /* slate-darkest */
   font-size: 0.75rem;
   line-height: 1.5;


### PR DESCRIPTION
## Summary
- Change `.sds-tooltip` background from `#f3f4f6` (gray-100) to `#ffffff` (white)
- Ensures consistent white background across all tooltip sizes

## Test plan
- [ ] Verify all tooltips (manufacturer, PR-Code, engine, copy) have white background

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Tooltip background updated to white for improved visual consistency.
* **New Features**
  * Tooltips now support per-element spacing so the distance from trigger to tooltip can be configured.
  * The code snippet tooltip display uses a slightly increased default offset for clearer separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->