### PR TITLE
style: add close-range shadow for small tooltips

### DIFF
--- a/src/styles/sds-tooltip.css
+++ b/src/styles/sds-tooltip.css
@@ -17,6 +17,7 @@
   line-height: 1.5;
   border-radius: 2px;
   box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.12),
     0 30px 90px -20px rgba(0, 0, 0, 0.3),
     0 0 0 1px #eaecf0;
   max-width: 280px;


### PR DESCRIPTION
## Summary
- Add `0 4px 16px rgba(0,0,0,0.12)` shadow layer visible on all tooltip sizes
- Existing deep shadow (`0 30px 90px -20px`) only visible on large tooltips (manufacturer)
- Small tooltips (copy button, PR-Code) now have consistent shadow

## Test plan
- [ ] Verify shadow visible on small tooltips (copy button, PR-Code)
- [ ] Verify manufacturer tooltip shadow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced tooltip visual depth with improved shadow effects for better visual hierarchy and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->