### PR TITLE
style: increase tooltip font-size to text-sm (14px)

### DIFF
--- a/src/styles/sds-tooltip.css
+++ b/src/styles/sds-tooltip.css
@@ -13,7 +13,7 @@
   z-index: 9999;
   background-color: #ffffff;
   color: #1e293b; /* slate-darkest */
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   line-height: 1.5;
   border-radius: 2px;
   box-shadow:


### PR DESCRIPTION
## Summary
- Change `.sds-tooltip` font-size from `0.75rem` (12px) to `0.875rem` (14px)
- Matches manufacturer tooltip content size (`text-sm`)

## Test plan
- [ ] Verify PR-Code tooltips match manufacturer tooltip font size
- [ ] Verify engine code tooltips still look good

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased tooltip text size for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->