### PR TITLE
style: darken engine code on hover and use pointer cursor

### DIFF
--- a/src/components/Product/ProductEngine.astro
+++ b/src/components/Product/ProductEngine.astro
@@ -35,7 +35,7 @@ const tooltipContent = getEngineTooltipContent(engine, translations);
   }
 
   .engine-code:hover {
-    @apply text-black decoration-blue-darker dark:text-white dark:decoration-blue-light;
+    @apply text-black decoration-blue-darker;
   }
 
   /* Semantic Engine Code Colors */

--- a/src/components/Product/ProductEngine.astro
+++ b/src/components/Product/ProductEngine.astro
@@ -30,12 +30,12 @@ const tooltipContent = getEngineTooltipContent(engine, translations);
   .engine-code {
     @apply inline-block mr-1;
     @apply underline decoration-dotted underline-offset-4 py-0.5;
-    @apply decoration-neutral-light cursor-default;
+    @apply decoration-neutral-light cursor-pointer;
     @apply transition-colors duration-200;
   }
 
   .engine-code:hover {
-    @apply decoration-blue-darker dark:decoration-blue-light;
+    @apply text-black decoration-blue-darker dark:text-white dark:decoration-blue-light;
   }
 
   /* Semantic Engine Code Colors */


### PR DESCRIPTION
## Summary
- Change engine code hover color to black (`text-black`)
- Change cursor from `cursor-default` to `cursor-pointer`

## Test plan
- [ ] Hover over engine code — text turns black, cursor is pointer
- [ ] Tooltip still appears correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated engine code element styling to better indicate interactivity with cursor changes and refined hover effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->