### PR TITLE
style: soften tooltip shadow opacity

### DIFF
--- a/src/styles/sds-tooltip.css
+++ b/src/styles/sds-tooltip.css
@@ -17,8 +17,8 @@
   line-height: 1.5;
   border-radius: 2px;
   box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.12),
-    0 30px 90px -20px rgba(0, 0, 0, 0.3),
+    0 4px 16px rgba(0, 0, 0, 0.08),
+    0 30px 90px -20px rgba(0, 0, 0, 0.15),
     0 0 0 1px #eaecf0;
   max-width: 280px;
   margin: 3px 0;


### PR DESCRIPTION
## Summary
- Reduce close shadow opacity from 0.12 to 0.08
- Reduce deep shadow opacity from 0.3 to 0.15
- Keeps px units (industry standard for box-shadow)

## Test plan
- [ ] Verify tooltip shadow is softer but still visible on all sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined tooltip shadow appearance with reduced opacity for a lighter, more subtle visual effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->