### PR TITLE
feat: accept optional numberFormatted prop in ProductNumber

### DIFF
--- a/src/components/Product/ProductNumber.astro
+++ b/src/components/Product/ProductNumber.astro
@@ -1,10 +1,17 @@
 ---
 import useFormatProductNumber from '../../utils/product/useFormatProductNumber';
 
-const { productNumber, isPdp = false, small = false, big = false, class: customClass = '' } = Astro.props;
+const {
+  productNumber,
+  numberFormatted,
+  isPdp = false,
+  small = false,
+  big = false,
+  class: customClass = '',
+} = Astro.props;
 
-// Use formatted product number using a helper function
-const { formattedNumbers: formatted } = useFormatProductNumber(productNumber);
+// Use API-provided number_formatted if available, otherwise compute client-side
+const formatted = numberFormatted ?? useFormatProductNumber(productNumber).formattedNumbers;
 
 // Define classes dynamically
 const classNames = ['product-number', big ? 'text-4.5' : 'number-big', customClass].filter(Boolean).join(' ');


### PR DESCRIPTION
## Summary
- ProductNumber now accepts optional `numberFormatted` prop (from panel API `number_formatted`)
- Falls back to client-side `useFormatProductNumber()` when not provided
- Backwards compatible — existing usage without the prop works unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced product number formatting to support API-provided values with local fallback for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->