### PR TITLE
fix: instant tooltip switch between adjacent targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.17",
+  "version": "1.38.18",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.14",
+  "version": "1.38.15",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.8",
+  "version": "1.38.9",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.16",
+  "version": "1.38.17",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.4",
+  "version": "1.38.5",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.3",
+  "version": "1.38.4",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.12",
+  "version": "1.38.13",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.15",
+  "version": "1.38.16",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.11",
+  "version": "1.38.12",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.7",
+  "version": "1.38.8",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.6",
+  "version": "1.38.7",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.5",
+  "version": "1.38.6",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.10",
+  "version": "1.38.11",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.9",
+  "version": "1.38.10",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.13",
+  "version": "1.38.14",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoko-design-system",
-  "version": "1.38.1",
+  "version": "1.38.2",
   "type": "module",
   "private": false,
   "main": "./index.ts",

--- a/src/scripts/tooltips.ts
+++ b/src/scripts/tooltips.ts
@@ -207,10 +207,13 @@ function handleMouseEnter(e: Event) {
   }
 
   if (showTimer) clearTimeout(showTimer);
+
+  // If tooltip is already visible (switching between targets), show immediately
+  const delay = currentTarget ? 0 : SHOW_DELAY;
   showTimer = setTimeout(() => {
     showTooltip(target);
     showTimer = null;
-  }, SHOW_DELAY);
+  }, delay);
 }
 
 function handleMouseLeave(e: Event) {

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-x border-neutral-lightest first:border-t hover:(outline outline-1 outline-neutral-light -outline-offset-1) ${TRANSITIONS.base}`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-neutral-lightest hover:(outline outline-1 outline-neutral-light -outline-offset-1) ${TRANSITIONS.base}`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-neutral-lightest hover:(outline outline-1 outline-neutral-light -outline-offset-1) ${TRANSITIONS.base}`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-neutral-lightest outline outline-1 outline-transparent hover:outline-neutral-light transition-outline-color duration-100`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-neutral-lightest outline outline-1 outline-transparent hover:outline-neutral-light transition-outline-color duration-100`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-neutral-lightest outline outline-1 outline-transparent hover:(outline-neutral-light border-neutral-light) transition-colors duration-100`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-neutral-lightest outline outline-1 outline-transparent hover:outline-neutral-light transition-outline-color duration-100`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-neutral-lightest border-r-3 border-r-transparent hover:border-r-neutral-light transition-border-color duration-100`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -57,7 +57,7 @@ export const componentShortcuts = [
 
   // PLP (Product List Page)
   ['plp-name', `${LAYOUT.flex.alignCenter} leading-none font-headregular cursor-pointer sm:pr-6 md:pr-12`],
-  ['plp-desc', `hidden sm:block col-span-3 md:col-span-1 md:col-start-3 ${LAYOUT.position.relative} px-2 sm:px-0`],
+  ['plp-desc', `hidden sm:block col-span-3 md:col-span-1 md:col-start-3 px-2 sm:px-0`],
   ['plp-materials', 'text-xs md:text-sm text-slate-darkest dark:text-neutral-light leading-tight font-textlight md:font-textregular whitespace-normal md:whitespace-pre-wrap'],
   ['plp-b-desc', `pb-4 ${COLORS.bgWhite} text-base ${LAYOUT.flex.wrap} mt-6`],
   ['plp-icons', `${LAYOUT.position.absolute} top-0 -right-2 md:(top-0.5 right-0) w-12 bottom-auto ${LAYOUT.flex.justifyEnd} text-sm`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-full grid grid-cols-3) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-0 border-b-1 border-b-neutral-lightest border-r-3 border-r-transparent hover:border-r-neutral-light transition-border-color duration-100`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5 sm:px-0) even:(pl-2.5 pr-3.5 sm:px-0) w-1/2 sm:(w-full grid grid-cols-3) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-0 border-b-1 border-b-neutral-lightest border-r-3 border-r-transparent hover:border-r-neutral-light transition-border-color duration-100`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-full grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-0 border-b-1 border-b-neutral-lightest border-r-3 border-r-transparent hover:border-r-neutral-light transition-border-color duration-100`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-full grid grid-cols-3) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-0 border-b-1 border-b-neutral-lightest border-r-3 border-r-transparent hover:border-r-neutral-light transition-border-color duration-100`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5 sm:px-0) even:(pl-2.5 pr-3.5 sm:px-0) w-1/2 sm:(w-full grid grid-cols-3) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-0 border-b-1 border-b-neutral-lightest border-r-3 border-r-transparent hover:(border-r-neutral-light border-b-neutral-light) transition-border-color duration-100`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5 sm:px-0) even:(pl-2.5 pr-3.5 sm:px-0) w-1/2 sm:(w-full grid grid-cols-3) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-0 border-b-1 border-b-neutral-lightest border-r-1 border-r-transparent hover:(border-r-neutral-light border-b-neutral-light) transition-border-color duration-100`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-neutral-lightest border-r-3 border-r-transparent hover:border-r-neutral-light transition-border-color duration-100`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-full grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-0 border-b-1 border-b-neutral-lightest border-r-3 border-r-transparent hover:border-r-neutral-light transition-border-color duration-100`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5 sm:px-0) even:(pl-2.5 pr-3.5 sm:px-0) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border border-neutral-lightest hover:border-neutral-light ${TRANSITIONS.base}`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border border-neutral-lightest hover:border-neutral-light ${TRANSITIONS.base}`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5 sm:px-0) even:(pl-2.5 pr-3.5 sm:px-0) w-1/2 sm:(w-auto grid grid-cols-3) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5 sm:px-0) even:(pl-2.5 pr-3.5 sm:px-0) w-1/2 sm:(w-auto grid grid-cols-3) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border border-transparent border-b-neutral-lighter hover:border-blue-lightest ${TRANSITIONS.base}`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border border-neutral-lightest hover:border-neutral-light ${TRANSITIONS.base}`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-x border-neutral-lightest first:border-t hover:(outline-1 outline-neutral-light -outline-offset-1) ${TRANSITIONS.base}`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -14,7 +14,7 @@ export const componentShortcuts = [
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],
-  ['product-row__main', 'w-full sm:w-auto col-span-2 leading-none relative sm:pl-1 md:(pl-0 row-start-1 col-start-2 col-span-1)'],
+  ['product-row__main', 'w-full sm:w-auto col-span-2 leading-none sm:pl-1 md:(pl-0 row-start-1 col-start-2 col-span-1)'],
 
   // Product elements
   ['product-number',`font-novamono content-center flex flex-wrap flex-col content-start pr-5 ${COLORS.bgWhite}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-neutral-lightest outline outline-1 outline-transparent hover:(outline-neutral-light border-neutral-light) transition-colors duration-100`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-neutral-lightest outline outline-1 outline-transparent hover:outline-neutral-light transition-outline-color duration-100`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5 sm:px-0) even:(pl-2.5 pr-3.5 sm:px-0) w-1/2 sm:(w-full grid grid-cols-3) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-0 border-b-1 border-b-neutral-lightest border-r-3 border-r-transparent hover:border-r-neutral-light transition-border-color duration-100`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5 sm:px-0) even:(pl-2.5 pr-3.5 sm:px-0) w-1/2 sm:(w-full grid grid-cols-3) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-0 border-b-1 border-b-neutral-lightest border-r-3 border-r-transparent hover:(border-r-neutral-light border-b-neutral-light) transition-border-color duration-100`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-x border-neutral-lightest first:border-t hover:(outline-1 outline-neutral-light -outline-offset-1) ${TRANSITIONS.base}`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5) even:(pl-2.5 pr-3.5) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border-b border-x border-neutral-lightest first:border-t hover:(outline outline-1 outline-neutral-light -outline-offset-1) ${TRANSITIONS.base}`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/components.ts
+++ b/uno-config/theme/shortcuts/components.ts
@@ -10,7 +10,7 @@ import {
 
 export const componentShortcuts = [
   // Product related
-  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5 sm:px-0) even:(pl-2.5 pr-3.5 sm:px-0) w-1/2 sm:(w-auto grid grid-cols-3) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border border-transparent border-b-neutral-lighter hover:border-blue-lightest ${TRANSITIONS.base}`],
+  ['product-row', `${COLORS.bgWhite} ${LAYOUT.flex.wrap} odd:(pr-2.5 pl-3.5 sm:px-0) even:(pl-2.5 pr-3.5 sm:px-0) w-1/2 sm:(w-auto grid grid-cols-3 px-2) gap-x-1 gap-y-0 md:(${LAYOUT.grid.product} gap-x-4) justify-start content-start content-start place-content-start py-4 pb-6 sm:pb-4 border border-neutral-lightest hover:border-neutral-light ${TRANSITIONS.base}`],
 
   ['product-row__photo', `${aspectRatios['4/3']} mb-2 sm:mb-0 ${IMAGE_STYLES.overlay} w-100 col-span-1 row-span-3 max-w-full text-left overflow-hidden ${LAYOUT.position.relative} ${COLORS.bgNeutralLightest} md:(col-span-1 row-span-1) box-content`],
   ['product-row__description', `${PRODUCT_STYLES.description.base} mt-2 ${PRODUCT_STYLES.description.md}`],

--- a/uno-config/theme/shortcuts/layout.ts
+++ b/uno-config/theme/shortcuts/layout.ts
@@ -29,7 +29,7 @@ export const layoutShortcuts = [
 
   // View Toggles
   ['view-grid', 'lg:flex-wrap'],
-  ['view-list', 'md:block lg:flex-col divide-y-1 divide-solid divide-neutral-lighter 4xl:(grid grid-cols-2 gap-14)'],
+  ['view-list', 'md:block lg:flex-col 4xl:(grid grid-cols-2 gap-14)'],
 
   // Containers
   ['products-container', 'products-wrapper'],

--- a/uno-config/theme/shortcuts/layout.ts
+++ b/uno-config/theme/shortcuts/layout.ts
@@ -33,7 +33,7 @@ export const layoutShortcuts = [
 
   // Containers
   ['products-container', 'products-wrapper'],
-  ['products-wrapper', `${LAYOUT.flex.wrap} ${COLORS.bgWhite} mb-4 w-full mb-auto md:(pl-4 px-2 -mt-3)`],
+  ['products-wrapper', `${LAYOUT.flex.wrap} ${COLORS.bgWhite} mb-4 w-full mb-auto md:(px-2 -mt-3)`],
   ['product-list', 'sm:block products-wrapper'],
   ['products-grid', `${LAYOUT.flex.alignCenter} w-full flex-nowrap pr-4 md:grid grid-rows-1 overflow-hidden ${LAYOUT.grid.cols2} lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 max-h-[6rem]`],
   ['similar-products', `${LAYOUT.flex.center} space-y-4 gap-8 flex-wrap px-4 md:grid ${LAYOUT.grid.cols2} lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5`],

--- a/uno-config/theme/shortcuts/layout.ts
+++ b/uno-config/theme/shortcuts/layout.ts
@@ -33,7 +33,7 @@ export const layoutShortcuts = [
 
   // Containers
   ['products-container', 'products-wrapper'],
-  ['products-wrapper', `${LAYOUT.flex.wrap} ${COLORS.bgWhite} mb-4 w-full mb-auto md:(px-2 -mt-3)`],
+  ['products-wrapper', `${LAYOUT.flex.wrap} ${COLORS.bgWhite} mb-4 w-full mb-auto`],
   ['product-list', 'sm:block products-wrapper'],
   ['products-grid', `${LAYOUT.flex.alignCenter} w-full flex-nowrap pr-4 md:grid grid-rows-1 overflow-hidden ${LAYOUT.grid.cols2} lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5 max-h-[6rem]`],
   ['similar-products', `${LAYOUT.flex.center} space-y-4 gap-8 flex-wrap px-4 md:grid ${LAYOUT.grid.cols2} lg:grid-cols-3 2xl:grid-cols-4 3xl:grid-cols-5`],


### PR DESCRIPTION
## Problem
When part links are close together (e.g. in a list), moving cursor from one to another causes tooltip to flicker/disappear because SHOW_DELAY (80ms) races with HIDE_DELAY (150ms).

## Fix
Skip SHOW_DELAY when tooltip is already visible (switching targets). Show new tooltip immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.38.18

* **Bug Fixes**
  * Improved tooltip display timing when switching between UI elements

* **Style**
  * Enhanced product row responsive layout with updated border styling and hover effects
  * Refined product description and list view styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->