### PR TITLE
fix: replace freepik urls with placehold.co to prevent netlify build failures

### DIFF
--- a/src/components/Carousel.astro
+++ b/src/components/Carousel.astro
@@ -3,8 +3,7 @@ export const productObject = {
   name: 'Combi-instrument MFA+',
   url: 'https://google.com',
   number: '6R0920870F',
-  photo:
-    'https://img.freepik.com/darmowe-wektory/tlo-retro-modeli-geometrycznych_52683-17902.jpg?w=1380&t=st=1706311337',
+  photo: 'https://placehold.co/400x300',
 };
 ---
 

--- a/src/components/ProductCarousel.astro
+++ b/src/components/ProductCarousel.astro
@@ -4,8 +4,7 @@ export const productObject = {
   name: 'Combi-instrument MFA+',
   url: 'https://google.com',
   number: '6R0920870F',
-  photo:
-    'https://img.freepik.com/darmowe-wektory/tlo-retro-modeli-geometrycznych_52683-17902.jpg?w=1380&t=st=1706311337',
+  photo: 'https://placehold.co/400x300',
 };
 ---
 

--- a/src/components/ProductTile.astro
+++ b/src/components/ProductTile.astro
@@ -11,7 +11,7 @@ import ProductNumber from './Product/ProductNumber.astro';
         {productObject.photo !== null ? (
           <Image
             imageObject={{
-              src: 'https://img.freepik.com/darmowe-wektory/tlo-retro-modeli-geometrycznych_52683-17902.jpg?w=1380&t=st=1706311337',
+              src: 'https://placehold.co/240x180',
               alt: 'Image Alt',
               height: '180',
               width: '240',

--- a/src/pages/components/card.mdx
+++ b/src/pages/components/card.mdx
@@ -13,7 +13,7 @@ Card - product link component which can be used for carousels, section with rela
 
 <div class="component-preview">
   <div class="grid grid-cols-1 md:grid-cols-3 gap-8 w-full" itemscope itemtype="https://schema.org/ItemList">
-    <Card href="https://google.com" imgAlt="Image Alt" imgSrc="https://img.freepik.com/free-photo/beautiful-green-landscape-with-plantations-trees-cloudy-sky_181624-42918.jpg?w=826&t=st=1706315168~exp=1706315768~hmac=ed7872d0924dbda4322a3d346eef282edd77db3673fc209c933b02e37c29f9ac" >
+    <Card href="https://google.com" imgAlt="Image Alt" imgSrc="https://placehold.co/826x620" >
         <a href="#">
             <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 leading-none">Lorem Ipsum</h5>
         </a>
@@ -31,7 +31,7 @@ Card - product link component which can be used for carousels, section with rela
         </Button>
     </Card>
 
-    <Card href="#" imgAlt="Image Alt" imgSrc="https://img.freepik.com/free-photo/beautiful-green-landscape-with-plantations-trees-cloudy-sky_181624-42918.jpg?w=826&t=st=1706315168~exp=1706315768~hmac=ed7872d0924dbda4322a3d346eef282edd77db3673fc209c933b02e37c29f9ac" >
+    <Card href="#" imgAlt="Image Alt" imgSrc="https://placehold.co/826x620" >
         <a href="#">
             <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 leading-none">Lorem Ipsum</h5>
         </a>
@@ -49,7 +49,7 @@ Card - product link component which can be used for carousels, section with rela
         </Button>
     </Card>
 
-    <Card href="#" imgAlt="Image Alt" imgSrc="https://img.freepik.com/free-photo/beautiful-green-landscape-with-plantations-trees-cloudy-sky_181624-42918.jpg?w=826&t=st=1706315168~exp=1706315768~hmac=ed7872d0924dbda4322a3d346eef282edd77db3673fc209c933b02e37c29f9ac" >
+    <Card href="#" imgAlt="Image Alt" imgSrc="https://placehold.co/826x620" >
         <a href="#">
             <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900  leading-none">Lorem Ipsum</h5>
         </a>
@@ -71,7 +71,7 @@ Card - product link component which can be used for carousels, section with rela
 
 ```html
 <div class="grid grid-cols-1 md:grid-cols-3 gap-8 w-full" itemscope itemtype="https://schema.org/ItemList">
-    <Card href="https://google.com" imgAlt="Image Alt" imgSrc="https://img.freepik.com/free-photo/beautiful-green-landscape-with-plantations-trees-cloudy-sky_181624-42918.jpg?w=826&t=st=1706315168~exp=1706315768~hmac=ed7872d0924dbda4322a3d346eef282edd77db3673fc209c933b02e37c29f9ac" >
+    <Card href="https://google.com" imgAlt="Image Alt" imgSrc="https://placehold.co/826x620" >
         <a href="#">
             <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900  leading-none">Lorem Ipsum</h5>
         </a>

--- a/src/pages/components/image.mdx
+++ b/src/pages/components/image.mdx
@@ -35,7 +35,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
   <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/darmowe-wektory/tlo-retro-modeli-geometrycznych_52683-17902.jpg?w=1380&t=st=1706311337',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -50,7 +50,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/beautiful-green-landscape-with-plantations-trees-cloudy-sky_181624-42918.jpg?w=970&t=st=1706315168',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -64,7 +64,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/lake-mountains_1204-508.jpg?w=970&t=st=1706315236',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -83,7 +83,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
   <Image
     imageObject={
       {
-        src: 'https://img.freepik.com/darmowe-wektory/tlo-retro-modeli-geometrycznych_52683-17902.jpg?w=1380&t=st=1706311337',
+        src: 'https://placehold.co/240x180',
         alt: 'Image Alt',
         height: '180',
         width: '240',
@@ -96,7 +96,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/beautiful-green-landscape-with-plantations-trees-cloudy-sky_181624-42918.jpg?w=970&t=st=1706315168',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -110,7 +110,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/lake-mountains_1204-508.jpg?w=970&t=st=1706315236',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -134,7 +134,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/darmowe-wektory/tlo-retro-modeli-geometrycznych_52683-17902.jpg?w=1380&t=st=1706311337',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -147,7 +147,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/beautiful-green-landscape-with-plantations-trees-cloudy-sky_181624-42918.jpg?w=970&t=st=1706315168',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -161,7 +161,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/lake-mountains_1204-508.jpg?w=970&t=st=1706315236',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -177,7 +177,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/darmowe-wektory/tlo-retro-modeli-geometrycznych_52683-17902.jpg?w=1380&t=st=1706311337',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -190,7 +190,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/beautiful-green-landscape-with-plantations-trees-cloudy-sky_181624-42918.jpg?w=970&t=st=1706315168',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -204,7 +204,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/lake-mountains_1204-508.jpg?w=970&t=st=1706315236',
+          src: 'https://placehold.co/240x180',
           alt: 'Image Alt',
           height: '180',
           width: '240',
@@ -223,7 +223,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/beautiful-green-landscape-with-plantations-trees-cloudy-sky_181624-42918.jpg?w=1970&t=st=1706315168',
+          src: 'https://placehold.co/1800x1350',
           alt: 'Image Alt',
           height: '1350',
           width: '1800',
@@ -239,7 +239,7 @@ Use `.img--overlay` class for images on white background to make a layer with li
  <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/beautiful-green-landscape-with-plantations-trees-cloudy-sky_181624-42918.jpg?w=1970&t=st=1706315168',
+          src: 'https://placehold.co/1800x1350',
           alt: 'Image Alt',
           height: '1350',
           width: '1800',
@@ -276,7 +276,7 @@ Ready-made CSS classes:
             <Image
             imageObject={
             {
-            src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+            src: 'https://placehold.co/700x700',
             alt: 'Image Alt',
             height: '700',
             width: '700',
@@ -292,7 +292,7 @@ Ready-made CSS classes:
             <Image
             imageObject={
             {
-            src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+            src: 'https://placehold.co/700x700',
             alt: 'Image Alt',
             height: '700',
             width: '700',
@@ -308,7 +308,7 @@ Ready-made CSS classes:
             <Image
             imageObject={
             {
-            src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+            src: 'https://placehold.co/700x700',
             alt: 'Image Alt',
             height: '700',
             width: '700',
@@ -323,7 +323,7 @@ Ready-made CSS classes:
             <Image
             imageObject={
             {
-            src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+            src: 'https://placehold.co/700x700',
             alt: 'Image Alt',
             height: '700',
             width: '700',
@@ -339,7 +339,7 @@ Ready-made CSS classes:
             <Image
             imageObject={
             {
-            src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+            src: 'https://placehold.co/700x700',
             alt: 'Image Alt',
             height: '700',
             width: '700',
@@ -354,7 +354,7 @@ Ready-made CSS classes:
             <Image
             imageObject={
             {
-            src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+            src: 'https://placehold.co/700x700',
             alt: 'Image Alt',
             height: '700',
             width: '700',
@@ -369,7 +369,7 @@ Ready-made CSS classes:
             <Image
             imageObject={
             {
-            src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+            src: 'https://placehold.co/700x700',
             alt: 'Image Alt',
             height: '700',
             width: '700',
@@ -388,7 +388,7 @@ Ready-made CSS classes:
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+          src: 'https://placehold.co/700x700',
           alt: 'Image Alt',
           height: '700',
           width: '700',
@@ -401,7 +401,7 @@ Ready-made CSS classes:
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+          src: 'https://placehold.co/700x700',
           alt: 'Image Alt',
           height: '700',
           width: '700',
@@ -414,7 +414,7 @@ Ready-made CSS classes:
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+          src: 'https://placehold.co/700x700',
           alt: 'Image Alt',
           height: '700',
           width: '700',
@@ -427,7 +427,7 @@ Ready-made CSS classes:
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+          src: 'https://placehold.co/700x700',
           alt: 'Image Alt',
           height: '700',
           width: '700',
@@ -440,7 +440,7 @@ Ready-made CSS classes:
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+          src: 'https://placehold.co/700x700',
           alt: 'Image Alt',
           height: '300',
           width: '300',
@@ -453,7 +453,7 @@ Ready-made CSS classes:
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+          src: 'https://placehold.co/700x700',
           alt: 'Image Alt',
           height: '700',
           width: '700',
@@ -466,7 +466,7 @@ Ready-made CSS classes:
     <Image
       imageObject={
         {
-          src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+          src: 'https://placehold.co/700x700',
           alt: 'Image Alt',
           height: '700',
           width: '700',
@@ -488,7 +488,7 @@ It is good to have all the images in the same ratio so that they look fairly uni
       <Image
         imageObject={
           {
-            src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+            src: 'https://placehold.co/700x700',
             alt: 'Image Alt',
             height: '700',
             width: '700',
@@ -503,7 +503,7 @@ It is good to have all the images in the same ratio so that they look fairly uni
   <Image
     imageObject={
       {
-        src: 'https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=960&ext=jpg',
+        src: 'https://placehold.co/700x700',
         alt: 'Image Alt',
         height: '700',
         width: '700',

--- a/src/pages/components/jumbotron.mdx
+++ b/src/pages/components/jumbotron.mdx
@@ -109,7 +109,7 @@ Perfect for page headers and key sections that need visual impact. Features a ba
       title="<b>Main Hero</b> Title"
       description="Detailed description of the hero section goes here."
       info="<span>Additional</span> information can be displayed here"
-      image="https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=1920&ext=jpg"
+      image="https://placehold.co/1920x1080"
     />
 </div>
 
@@ -119,7 +119,7 @@ Perfect for page headers and key sections that need visual impact. Features a ba
   title="<b>Main Hero</b> Title"
   description="Detailed description of the hero section goes here."
   info="<span>Additional</span> information can be displayed here"
-  image="https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=1920&ext=jpg"
+  image="https://placehold.co/1920x1080"
 />
 ```
 
@@ -232,7 +232,7 @@ Designed for blog posts and articles, featuring a full-width image overlay with 
     <Jumbotron
       variant="post"
       title="Blog Post Title"
-      image="https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=1920&ext=jpg"
+      image="https://placehold.co/1920x1080"
       categories={[
         { name: 'Technology', link: '#' },
         { name: 'Design', link: '#' }
@@ -249,7 +249,7 @@ Designed for blog posts and articles, featuring a full-width image overlay with 
 <Jumbotron
   variant="post"
   title="Blog Post Title"
-  image="https://img.freepik.com/free-photo/nature-beauty-tropical-rainforest-adventure-tranquility-freshness-generated-by-artificial-intellingence_25030-62539.jpg?size=1920&ext=jpg"
+  image="https://placehold.co/1920x1080"
   categories={[
     { name: 'Technology', link: '#' },
     { name: 'Design', link: '#' }
@@ -269,7 +269,7 @@ A two-column layout variant for posts where image and content need equal emphasi
     <Jumbotron
       variant="post-split"
       title="<b>Formatted</b> Blog Post Title <small>Lorem Ipsum</small>"
-      image="https://img.freepik.com/premium-photo/tranquil-scene-nature-beauty-tropical-rainforest-adventure-generated-by-artificial-intelligence_188544-83820.jpg?w=1200&h=675&f=webp"
+      image="https://placehold.co/1200x675"
       categories={[
         { name: 'Technology', link: '#' },
         { name: 'Design', link: '#' }
@@ -362,7 +362,7 @@ Use the `slim` prop to reduce vertical padding and image height. Useful for seco
     <Jumbotron
       variant="post-split"
       title="Slim Post Split"
-      image="https://img.freepik.com/premium-photo/tranquil-scene-nature-beauty-tropical-rainforest-adventure-generated-by-artificial-intelligence_188544-83820.jpg?w=1200&h=675&f=webp"
+      image="https://placehold.co/1200x675"
       slim
     />
 </div>
@@ -383,7 +383,7 @@ Use the `split` prop to control the column width ratio between text and image on
     <Jumbotron
       variant="post-split"
       title="Wide Split (2/3 + 1/3)"
-      image="https://img.freepik.com/premium-photo/tranquil-scene-nature-beauty-tropical-rainforest-adventure-generated-by-artificial-intelligence_188544-83820.jpg?w=1200&h=675&f=webp"
+      image="https://placehold.co/1200x675"
       split="wide"
     />
 </div>
@@ -404,7 +404,7 @@ Combine `slim` and `split="wide"` for a compact layout with 2/3 + 1/3 column rat
     <Jumbotron
       variant="post-split"
       title="Slim Wide Split"
-      image="https://img.freepik.com/premium-photo/tranquil-scene-nature-beauty-tropical-rainforest-adventure-generated-by-artificial-intelligence_188544-83820.jpg?w=1200&h=675&f=webp"
+      image="https://placehold.co/1200x675"
       slim
       split="wide"
     />
@@ -427,7 +427,7 @@ Use the `align` prop to control text alignment within the content area. Availabl
     <Jumbotron
       variant="post-split"
       title="Left Aligned Content"
-      image="https://img.freepik.com/premium-photo/tranquil-scene-nature-beauty-tropical-rainforest-adventure-generated-by-artificial-intelligence_188544-83820.jpg?w=1200&h=675&f=webp"
+      image="https://placehold.co/1200x675"
       align="left"
     />
 </div>
@@ -445,7 +445,7 @@ Use the `align` prop to control text alignment within the content area. Availabl
     <Jumbotron
       variant="post-split"
       title="Center Aligned Content"
-      image="https://img.freepik.com/premium-photo/tranquil-scene-nature-beauty-tropical-rainforest-adventure-generated-by-artificial-intelligence_188544-83820.jpg?w=1200&h=675&f=webp"
+      image="https://placehold.co/1200x675"
       align="center"
     />
 </div>

--- a/src/pages/components/post-header.mdx
+++ b/src/pages/components/post-header.mdx
@@ -22,7 +22,7 @@ WordPress PostHeader - post top component for WordPress Single Post template dat
       categories={categories}
       title="Lorem Ipsum"
       date={date}
-      image="https://img.freepik.com/free-photo/morskie-oko-tatry_1204-510.jpg?w=1380&t=st=1706297574~exp=1706298174~hmac=5c93e7317e7dbe602d5dcd708c5b9708ffabcb5e8ab2b7f2790941975dfcefe4"
+      image="https://placehold.co/1380x920"
     />
   </div>
 </div>
@@ -35,7 +35,7 @@ WordPress PostHeader - post top component for WordPress Single Post template dat
       categories={  [{"name":"Tools & garage accessories","uri":"/category/garage/tools-garage-accessories/"}, , {"name":"Lorem Ipsum","uri":"#"}] }
             title="Lorem Ipsum"
       date="2023-07-13T01:35:03"
-      image="https://img.freepik.com/free-photo/morskie-oko-tatry_1204-510.jpg?w=1380&t=st=1706297574~exp=1706298174~hmac=5c93e7317e7dbe602d5dcd708c5b9708ffabcb5e8ab2b7f2790941975dfcefe4"
+      image="https://placehold.co/1380x920"
     />
   </div>
 ```
@@ -48,7 +48,7 @@ WordPress PostHeader - post top component for WordPress Single Post template dat
     <PostHeader
       title="Lorem Ipsum"
       lang="en"
-      image="https://img.freepik.com/free-photo/painting-mountain-lake-with-mountain-background_188544-9126.jpg?w=1380&t=st=1706297408~exp=1706298008~hmac=34fe549db6a665d24269d38a8ecdd7eb3f82cfea6346c8a4039ee3c03b62aad8"
+      image="https://placehold.co/1380x920"
     />
   </div>
 </div>
@@ -58,7 +58,7 @@ WordPress PostHeader - post top component for WordPress Single Post template dat
     <PostHeader
       title="Lorem Ipsum"
       lang="en"
-      image="https://img.freepik.com/free-photo/painting-mountain-lake-with-mountain-background_188544-9126.jpg?w=1380&t=st=1706297408~exp=1706298008~hmac=34fe549db6a665d24269d38a8ecdd7eb3f82cfea6346c8a4039ee3c03b62aad8"
+      image="https://placehold.co/1380x920"
     />
   </div>
 ```

--- a/src/pages/components/product-tile.mdx
+++ b/src/pages/components/product-tile.mdx
@@ -8,7 +8,7 @@ export const productObject = {
   name: 'Combi-instrument MFA+',
   url: 'https://google.com',
   number: '6R0920870F',
-  photo: 'https://img.freepik.com/darmowe-wektory/tlo-retro-modeli-geometrycznych_52683-17902.jpg?w=1380&t=st=1706311337'
+  photo: 'https://placehold.co/400x300'
 }
 
 # ProductTile
@@ -44,7 +44,7 @@ export const productObject = {
   name: 'Combi-instrument MFA+',
   url: 'https://google.com',
   number: '6R0920870F',
-  photo: 'https://img.freepik.com/darmowe-wektory/tlo-retro-modeli-geometrycznych_52683-17902.jpg?w=1380&t=st=1706311337'
+  photo: 'https://placehold.co/400x300'
 }
 
 <ProductTile productObject={productObject} />

--- a/src/scripts/tooltips.ts
+++ b/src/scripts/tooltips.ts
@@ -219,7 +219,8 @@ function handleMouseEnter(e: Event) {
 }
 
 function handleMouseLeave(e: Event) {
-  const el = e.target as HTMLElement;
+  const me = e as MouseEvent;
+  const el = me.target as HTMLElement;
 
   // Leaving the tooltip itself — schedule hide
   if (isInteractive && tooltipEl && (el === tooltipEl || tooltipEl.contains(el))) {
@@ -232,6 +233,10 @@ function handleMouseLeave(e: Event) {
 
   const target = el.closest?.(SELECTOR);
   if (!(target instanceof HTMLElement)) return;
+
+  // If cursor is moving to a child/parent within the same tooltip target, ignore
+  const related = me.relatedTarget as HTMLElement | null;
+  if (related && target.contains(related)) return;
 
   if (showTimer) {
     clearTimeout(showTimer);


### PR DESCRIPTION
## Summary
- Freepik URLs were returning HTTP redirects, causing Astro's `loadRemoteImage` to fail during build with `Failed to load remote image. The request was redirected.`
- Replaced all 25+ Freepik URL instances with `placehold.co` placeholders (already whitelisted in `astro.config.mjs`)
- Affected 8 files: `image.mdx`, `card.mdx`, `jumbotron.mdx`, `post-header.mdx`, `product-tile.mdx`, `Carousel.astro`, `ProductCarousel.astro`, `ProductTile.astro`

## Test plan
- [x] Local `pnpm run build` passes (34 pages built in ~30s)
- [ ] Netlify deploy preview build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip behavior to prevent unintended dismissal when moving your cursor within the tooltip area or to closely related elements

* **Chores**
  * Replaced external image URLs with consistent placeholder images across all component examples and documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->