### PR TITLE
fix(ci): unblock main CI after Astro 6 upgrade

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install, build, and upload your site
         uses: withastro/action@v6
         with:
-          package-manager: pnpm@10.30.3
+          package-manager: pnpm@10.32.1
           node-version: 22
 
   deploy:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,7 +21,10 @@ export default defineConfig({
   },
   image: {
     service: sharpImageService(),
-    domains: ["placehold.co", "api.polo.blue", "polo.blue", "media.istockphoto.com", "freepik.com", "img.freepik.com", "polo6r.pl"]
+    domains: ["placehold.co", "api.polo.blue", "polo.blue", "media.istockphoto.com", "freepik.com", "img.freepik.com", "polo6r.pl"],
+    // Astro 6 disabled SVG processing by default; restore Astro 5 behavior
+    // since placehold.co (used in docs demos) returns SVG without an extension.
+    dangerouslyProcessSVG: true,
   },
   integrations: [
     // Enable Vue to support Vue3 components


### PR DESCRIPTION
## Summary

Two regressions surfaced on `main` after PR #456 merged:

- **Deploy to GitHub Pages** — `deploy.yml` pinned `package-manager: pnpm@10.30.3` while `pnpm up --latest` in #456 bumped package.json's `packageManager` to `pnpm@10.32.1`. `pnpm/action-setup` rejects this mismatch.
- **Release (semantic-release)** — Astro 6 disabled SVG image processing by default. `placehold.co/240x180` (used in docs demos) returns SVG without an extension, breaking the build with `UnsupportedImageFormat`.

## Fix

- `deploy.yml`: bump `pnpm@10.30.3 → pnpm@10.32.1` to match `packageManager`
- `astro.config.mjs`: `image.dangerouslyProcessSVG: true` (restores Astro 5 default behavior)

## Test plan

- [x] `pnpm build` passes locally (39 pages, no errors)
- [ ] Release workflow runs to completion on main → semantic-release publishes
- [ ] Deploy to GH Pages succeeds