### PR TITLE
docs(homepage): tighten Multi-Framework feature copy

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,7 +51,7 @@ const features = [
     title: 'Multi-Framework',
     icon: 'streamline-freehand-color:module-building-blocks',
     description:
-      'Framework-agnostic core (CSS recipes + vanilla TS) with thin wrappers for <a href="https://vuejs.org/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline transition-colors">Vue 3</a> and <a href="https://astro.build/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline transition-colors">Astro</a> today — React wrappers shipping via the <a href="https://github.com/polo-blue/sds/blob/main/UNIVERSAL-MIGRATION-PLAN.md" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline transition-colors">universal split</a>, plain HTML supported via the prebuilt stylesheet.',
+      'Thin wrappers for <a href="https://vuejs.org/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline transition-colors">Vue 3</a> and <a href="https://astro.build/" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline transition-colors">Astro</a> today, plain HTML via the prebuilt stylesheet. React next via the <a href="https://github.com/polo-blue/sds/blob/main/UNIVERSAL-MIGRATION-PLAN.md" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline transition-colors">universal split</a>.',
   },
   {
     title: 'Design Patterns',


### PR DESCRIPTION
## Summary

- Tighten the Multi-Framework card on the homepage so its length matches neighboring feature cards
- Same 4 facts (Vue 3, Astro, plain HTML, React next) in two short sentences
- No behavior or layout change, copy only

## Test plan

- [ ] Netlify deploy preview renders the homepage with the shorter copy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Multi-Framework feature description to clarify support options for Vue 3, Astro, and React integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->