### PR TITLE
fix(Header): repair navbar dark-mode toggle (duplicate listeners)

### DIFF
--- a/.astro/types.d.ts
+++ b/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ pnpm-debug.log*
 # testing
 coverage/
 .nyc_output/
+test-results/
+playwright-report/
+blob-report/
+.playwright/
 
 # IDE files (keep shared .vscode config, ignore personal settings)
 .vscode/settings.local.json

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint": "eslint \"src/**/*.{js,ts,jsx,tsx,vue,astro}\"",
     "lint:fix": "eslint \"src/**/*.{js,ts,jsx,tsx,vue,astro}\" --fix",
     "check": "astro check",
+    "test:e2e": "playwright test",
     "prepare": "husky"
   },
   "repository": {
@@ -127,6 +128,7 @@
     "@commitlint/cli": "^21.0.2",
     "@commitlint/config-conventional": "^21.0.2",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.50.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/culori": "^4.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 1234;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,6 +196,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.5.0(jiti@2.6.1))
+      '@playwright/test':
+        specifier: ^1.50.0
+        version: 1.61.0
       '@semantic-release/changelog':
         specifier: ^6.0.3
         version: 6.0.3(semantic-release@25.0.5(typescript@5.9.2))
@@ -1742,6 +1745,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -3542,6 +3550,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4973,6 +4986,16 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -7939,6 +7962,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -10041,6 +10068,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -11713,6 +11743,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -135,11 +135,16 @@ import SearchModal from './SearchModal.vue';
 <script>
   function setupDarkModeToggle() {
     const toggle = document.getElementById('dark-mode-toggle');
-    if (toggle) {
+    if (toggle && toggle.dataset.bound !== '1') {
+      toggle.dataset.bound = '1';
       toggle.addEventListener('click', () => {
         const isDark = document.documentElement.classList.toggle('dark');
         document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
-        localStorage.setItem('sds-color-scheme', isDark ? 'dark' : 'light');
+        try {
+          localStorage.setItem('sds-color-scheme', isDark ? 'dark' : 'light');
+        } catch {
+          /* localStorage may be unavailable */
+        }
       });
     }
   }

--- a/tests/dark-mode-toggle.spec.ts
+++ b/tests/dark-mode-toggle.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Regression test for the navbar dark-mode toggle.
+ *
+ * Bug: `setupDarkModeToggle()` in Header.astro ran three times (immediate call +
+ * `astro:page-load` + `astro:after-swap`) with no guard, attaching multiple click
+ * listeners to the same `#dark-mode-toggle` button. Each click toggled `.dark` an
+ * even number of times, so the theme never visibly changed — switching to light
+ * mode (or back) appeared broken.
+ *
+ * These tests assert that a single click flips the theme exactly once and that the
+ * choice persists to localStorage and survives a reload.
+ */
+
+const TOGGLE = '#dark-mode-toggle';
+// A docs page that uses MainLayout, where the navbar dark-mode toggle is rendered.
+const PAGE = '/core/introduction/';
+// Matches the `dark` class as a standalone token in the <html> class list.
+const DARK_CLASS = /(^|\s)dark(\s|$)/;
+
+test.describe('navbar dark-mode toggle', () => {
+  // Force a deterministic starting point: emulate the light system preference so the
+  // page boots in light mode regardless of the runner's OS settings.
+  test.use({ colorScheme: 'light' });
+
+  test.beforeEach(async ({ page }) => {
+    // Each test runs in an isolated browser context with empty localStorage, so the
+    // `colorScheme: 'light'` emulation above is enough to boot deterministically in
+    // light mode — no manual storage reset needed (resetting here would also wipe the
+    // value on reload and break the persistence test).
+    await page.goto(PAGE);
+    // Wait for the toggle to be wired before interacting.
+    await expect(page.locator(TOGGLE)).toBeVisible();
+  });
+
+  test('starts in light mode', async ({ page }) => {
+    await expect(page.locator('html')).not.toHaveClass(DARK_CLASS);
+  });
+
+  test('a single click switches to dark mode', async ({ page }) => {
+    await page.locator(TOGGLE).click();
+
+    await expect(page.locator('html')).toHaveClass(DARK_CLASS);
+    await expect(page.locator('html')).toHaveCSS('color-scheme', 'dark');
+
+    const stored = await page.evaluate(() => window.localStorage.getItem('sds-color-scheme'));
+    expect(stored).toBe('dark');
+  });
+
+  test('clicking twice returns to light mode (the regression)', async ({ page }) => {
+    const html = page.locator('html');
+
+    await page.locator(TOGGLE).click();
+    await expect(html).toHaveClass(DARK_CLASS);
+
+    await page.locator(TOGGLE).click();
+    // With the double-bind bug this stayed dark; one listener now flips it back.
+    await expect(html).not.toHaveClass(DARK_CLASS);
+    await expect(html).toHaveCSS('color-scheme', 'light');
+
+    const stored = await page.evaluate(() => window.localStorage.getItem('sds-color-scheme'));
+    expect(stored).toBe('light');
+  });
+
+  test('the chosen theme persists across a reload', async ({ page }) => {
+    await page.locator(TOGGLE).click();
+    await expect(page.locator('html')).toHaveClass(DARK_CLASS);
+
+    await page.reload();
+    await expect(page.locator('html')).toHaveClass(DARK_CLASS);
+  });
+});


### PR DESCRIPTION
## Problem

Switching the theme via the navbar `#dark-mode-toggle` button appeared broken — clicks (especially back to light mode) had no visible effect.

## Root cause

`setupDarkModeToggle()` in `Header.astro` ran **three times** — the immediate call plus `astro:page-load` and `astro:after-swap` (`<ClientRouter />` is active) — with **no guard against re-binding**. Each run attached another `click` listener to the same button, so every click toggled `.dark` an even number of times → net no change.

## Fix

- Add the same `dataset.bound` guard already used in `MenuDrawer.astro` so the listener binds exactly once.
- Wrap `localStorage.setItem` in `try/catch` for parity with MenuDrawer (blocked/private-mode storage).

## Tests

Bootstraps Playwright (no e2e setup existed before) and adds a regression suite for the toggle:

- starts in light mode
- single click → dark (class + `color-scheme` + localStorage)
- **click twice → back to light** (the regression)
- choice persists across reload

All 4 pass; verified they **fail on the pre-fix code**.

Run locally with `pnpm test:e2e`.

## Notes / follow-up

The toggle logic now lives in 3 places (`MainLayout` init script, `Header`, `MenuDrawer`). Out of scope here, but a shared `toggleColorScheme()` util would be the cleaner long-term shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for dark-mode toggle functionality, including theme persistence across page reloads.

* **Bug Fixes**
  * Fixed dark-mode toggle to prevent multiple event listener bindings.
  * Added error handling for localStorage operations.

* **Chores**
  * Added Playwright testing framework and configuration.
  * Updated project configuration and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->